### PR TITLE
docs: add explicit schema tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,10 +214,31 @@ Paystack documents these as `code` + `token`. If the server cannot fetch `emailT
 
 ## Schema
 
-The plugin adds:
+The plugin adds the following to your Better Auth database schema.
 
-- `user.paystackCustomerCode?: string`
-- `subscription` table with fields like: `plan`, `referenceId`, `paystackCustomerCode`, `paystackSubscriptionCode`, `paystackTransactionReference`, `status`, and optional period/trial fields.
+### `user`
+
+| Field | Type | Required | Default |
+| --- | --- | --- | --- |
+| `paystackCustomerCode` | `string` | no | — |
+
+### `subscription` (only when `subscription.enabled: true`)
+
+| Field | Type | Required | Default |
+| --- | --- | --- | --- |
+| `plan` | `string` | yes | — |
+| `referenceId` | `string` | yes | — |
+| `paystackCustomerCode` | `string` | no | — |
+| `paystackSubscriptionCode` | `string` | no | — |
+| `paystackTransactionReference` | `string` | no | — |
+| `status` | `string` | no | `"incomplete"` |
+| `periodStart` | `date` | no | — |
+| `periodEnd` | `date` | no | — |
+| `trialStart` | `date` | no | — |
+| `trialEnd` | `date` | no | — |
+| `cancelAtPeriodEnd` | `boolean` | no | `false` |
+| `groupId` | `string` | no | — |
+| `seats` | `number` | no | — |
 
 ## Options
 


### PR DESCRIPTION
Adds explicit markdown tables for the plugin-added schema (user + subscription) to help users who set up schema manually.\n\nCloses #3.