### PR TITLE
chore: release v0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexasomba/better-auth-paystack",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Community Better Auth plugin for Paystack (by alexasomba)",
   "license": "MIT",
   "author": "alexasomba",


### PR DESCRIPTION
Release v0.1.0.

- Bumps package version from 0.0.4 -> 0.1.0
- No code changes; tests/typecheck/build already verified on main

After merge, create tag `v0.1.0` to trigger the publish workflow.