### PR TITLE
chore(ci): create GitHub Release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,9 @@ jobs:
         run: pnpm publish --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
Adds a step to  to create a GitHub Release object for the pushed tag (generate release notes).

This keeps npm publish + GitHub Releases in sync.