### PR TITLE
chore: release v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alexasomba/better-auth-paystack",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Community Better Auth plugin for Paystack (by alexasomba)",
   "license": "MIT",
   "author": "alexasomba",


### PR DESCRIPTION
Release v0.1.1.

- Bumps package version from 0.1.0 -> 0.1.1
- No code changes

After merge, tag  to trigger the Release workflow (now also creates a GitHub Release object).