### PR TITLE
feat: re-apply missing v2.0.0 features (IP whitelisting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A TypeScript-first plugin that integrates Paystack into [Better Auth](https://ww
 - [x] **Scheduled Changes**: Defer subscription updates or cancellations to the end of the billing cycle.
 - [x] **Proration**: Immediate mid-cycle prorated charges for seat and plan upgrades.
 - [x] **Popup Modal Flow**: Optional support for Paystack's inline checkout experience via `@alexasomba/paystack-browser`.
-- [x] **Webhook Security**: Pre-configured signature verification (HMAC-SHA512).
+- [x] **Webhook Security**: Pre-configured signature verification (HMAC-SHA512) and optional IP whitelisting.
 - [x] **Transaction History**: Built-in support for listing and viewing local transaction records.
 
 ---
@@ -295,6 +295,20 @@ await authClient.paystack.transaction.initialize({
   plan: "pro",
   quantity: 5, // Upgrading seats
   prorateAndCharge: true, // Will calculate and charge the prorated amount instantly
+});
+```
+
+### Webhook Security
+
+The plugin automatically verifies the `x-paystack-signature` header to ensure events are authentic. For an extra layer of security, you can enable **IP Whitelisting** to restrict processing to Paystack's official servers.
+
+```ts
+paystack({
+  webhook: {
+    secret: process.env.PAYSTACK_WEBHOOK_SECRET!,
+    verifyIP: true, // Enable IP whitelisting (defaults to false for flexible proxy support)
+    trustedIPs: ["52.31.139.75", "52.49.173.169", "52.214.14.220"], // Optional: override trusted IPs
+  },
 });
 ```
 

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -129,6 +129,29 @@ export const paystackWebhook = <P extends string = "/webhook">(
         (ctx.request as unknown as { headers: Headers })?.headers;
       const signature = headers?.get("x-paystack-signature") as string | null | undefined;
 
+      if (options.webhook?.verifyIP === true) {
+        const trustedIPs = options.webhook.trustedIPs ?? [
+          "52.31.139.75",
+          "52.49.173.169",
+          "52.214.14.220",
+        ];
+        const clientIP =
+          headers?.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+          headers?.get("x-real-ip") ??
+          (ctx.request as unknown as { ip?: string }).ip;
+
+        if (
+          clientIP !== undefined &&
+          clientIP !== null &&
+          trustedIPs.includes(clientIP) === false
+        ) {
+          throw new APIError("UNAUTHORIZED", {
+            message: `Forbidden IP: ${clientIP}`,
+            status: 401,
+          });
+        }
+      }
+
       if (signature === undefined || signature === null || signature === "") {
         throw new APIError("UNAUTHORIZED", {
           message: "Missing x-paystack-signature header",

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,16 @@ export interface PaystackOptions<TPaystackClient extends PaystackClientLike = Pa
      * Webhook secret for signature verification
      */
     secret?: string;
+    /**
+     * Whether to verify the request origin IP address
+     * @default false
+     */
+    verifyIP?: boolean;
+    /**
+     * List of trusted IP addresses for webhooks.
+     * Defaults to official Paystack IPs if verifyIP is true and this is empty.
+     */
+    trustedIPs?: string[];
   };
   /**
    * Subscription configuration


### PR DESCRIPTION
## Overview
This PR re-applies the **IP Whitelisting** security feature that was inadvertently excluded from the v2.0.0 squash merge.

## Changes
- **src/types.ts**: Restored `verifyIP` and `trustedIPs` options.
- **src/routes.ts**: Restored the IP verification logic in the webhook handler.
- **README.md**: Restored the Webhook Security documentation section.