### PR TITLE
Enforce v-prefixed release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v*.*.*"
 
 permissions:
   contents: write
@@ -21,6 +21,15 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 24.x
+
+      - name: Validate release tag
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error ::Release tags must use vX.X.X format, for example v2.4.1."
+            exit 1
+          fi
 
       - uses: pnpm/action-setup@v4
         with: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.4.1](https://github.com/alexasomba/better-auth-paystack/compare/v2.4.0...v2.4.1) (2026-05-09)
+
+### Documentation
+
+- add TanStack Intent skills for setup, subscriptions, organization billing, TanStack Start, products, plans, trials, seats, and limits ([#119](https://github.com/alexasomba/better-auth-paystack/issues/119))
+
+### Miscellaneous Chores
+
+- align package runtime version and Intent skill metadata with the 2.4.1 release
+- enforce plain `vX.X.X` release tags for automated releases
+
 # [2.0.0](https://github.com/alexasomba/better-auth-paystack/compare/v1.2.1...v2.0.0) (2026-04-17)
 
 ### Features

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,53 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
+  "include-v-in-tag": true,
+  "include-v-in-release-name": true,
   "packages": {
     ".": {
       "release-type": "node",
       "package-name": "@alexasomba/better-auth-paystack",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true,
+      "include-v-in-release-name": true,
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "src/version.ts"
+        },
+        {
+          "type": "yaml",
+          "path": "_artifacts/domain_map.yaml",
+          "jsonpath": "$.library.version"
+        },
+        {
+          "type": "yaml",
+          "path": "_artifacts/skill_tree.yaml",
+          "jsonpath": "$.library.version"
+        },
+        {
+          "type": "generic",
+          "path": "skills/setup/SKILL.md"
+        },
+        {
+          "type": "generic",
+          "path": "skills/subscriptions-and-transactions/SKILL.md"
+        },
+        {
+          "type": "generic",
+          "path": "skills/organization-billing/SKILL.md"
+        },
+        {
+          "type": "generic",
+          "path": "skills/tanstack-start/SKILL.md"
+        },
+        {
+          "type": "generic",
+          "path": "skills/billing-catalog-and-limits/SKILL.md"
+        }
+      ]
     }
   },
   "changelog-sections": [

--- a/skills/billing-catalog-and-limits/SKILL.md
+++ b/skills/billing-catalog-and-limits/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Configure products, Paystack-native plans, local-managed plans, free trials, seat billing, resource limits, and catalog sync in @alexasomba/better-auth-paystack. Use when tasks mention planCode, freeTrial, trial eligibility, seatAmount, seatPlanCode, limits, products, syncPaystackProducts, or syncPaystackPlans.
 type: core
 library: "@alexasomba/better-auth-paystack"
-library_version: "2.4.1"
+library_version: "2.4.1" # x-release-please-version
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/types.ts"

--- a/skills/organization-billing/SKILL.md
+++ b/skills/organization-billing/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Configure organization billing in @alexasomba/better-auth-paystack. Use for organization.enabled, Better Auth organization plugin setup, owner/admin default billing authorization, subscription.authorizeReference, organization Paystack customers, seats, invitations, members, and team limits.
 type: core
 library: "@alexasomba/better-auth-paystack"
-library_version: "2.4.1"
+library_version: "2.4.1" # x-release-please-version
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/index.ts"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Configure @alexasomba/better-auth-paystack with Better Auth. Use when adding the paystack() server plugin, paystackClient() client plugin, schema overrides, products/plans, webhook secrets, or canonical authClient.paystack/subscription/transaction actions.
 type: core
 library: "@alexasomba/better-auth-paystack"
-library_version: "2.4.1"
+library_version: "2.4.1" # x-release-please-version
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/index.ts"

--- a/skills/subscriptions-and-transactions/SKILL.md
+++ b/skills/subscriptions-and-transactions/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Build Paystack transaction and subscription flows with @alexasomba/better-auth-paystack. Use for initialize/verify transaction, create/upgrade/cancel/restore/list subscriptions, products/plans, billing portal links, webhooks, chargeSubscriptionRenewal, syncPaystackProducts, and syncPaystackPlans.
 type: core
 library: "@alexasomba/better-auth-paystack"
-library_version: "2.4.1"
+library_version: "2.4.1" # x-release-please-version
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/routes.ts"

--- a/skills/tanstack-start/SKILL.md
+++ b/skills/tanstack-start/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Integrate @alexasomba/better-auth-paystack in TanStack Start. Use for Better Auth API routes, tanstackStartCookies(), server functions, getRequestHeaders(), authClient Paystack actions, admin billing server functions, and Cloudflare Workers deployment.
 type: composition
 library: "@alexasomba/better-auth-paystack"
-library_version: "2.4.1"
+library_version: "2.4.1" # x-release-please-version
 sources:
   - "alexasomba/better-auth-paystack:examples/tanstack/README.md"
   - "alexasomba/better-auth-paystack:examples/tanstack/src/lib/auth.ts"

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const PACKAGE_VERSION = "2.4.1";
+export const PACKAGE_VERSION = "2.4.1"; // x-release-please-version


### PR DESCRIPTION
## Summary
- configure release-please to create plain vX.X.X tags and release names instead of component-prefixed tags
- wire release-please extra-files so src/version.ts and Intent skill metadata stay in sync on future release PRs
- add a release workflow guard that rejects non-vX.X.X tags
- add the 2.4.1 changelog entry now that the 2.4.1 version bump has landed

## Verification
- npx @tanstack/intent@latest validate skills
- vp check
- vp test
- vp pack