### PR TITLE
Update Paystack SDK and TanStack example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ dist/
 .github/copilot-instructions.md
 ci-artifacts/
 coverage/
+playwright-report/
+test-results/
+examples/*/playwright-report/
+examples/*/test-results/
 
 # TypeScript build cache
 *.tsbuildinfo

--- a/examples/tanstack/e2e/dashboard-flows.spec.ts
+++ b/examples/tanstack/e2e/dashboard-flows.spec.ts
@@ -1,0 +1,114 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function signInAnonymously(page: Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Login Anonymously" }).click();
+  await expect(page).toHaveURL(/.*dashboard/, { timeout: 15_000 });
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+}
+
+function uniqueName(prefix: string) {
+  return `${prefix} ${Date.now().toString(36)} ${Math.random().toString(36).slice(2, 7)}`;
+}
+
+async function createOrganization(page: Page, name = uniqueName("Acme Test Co")) {
+  await page.getByRole("tab", { name: "Organizations" }).click();
+  await page.getByRole("button", { name: "New Organization" }).click();
+  await page.getByLabel("Organization Name *").fill(name);
+  await page.getByRole("button", { name: "Create Organization" }).click();
+
+  await expect(page.getByText(name).first()).toBeVisible();
+  await expect(page.getByText(`/${name.toLowerCase().replaceAll(" ", "-")}`)).toBeVisible();
+  await expect(page.getByText(/^referenceId:/)).toBeVisible();
+
+  return name;
+}
+
+test.describe("TanStack example dashboard flows", () => {
+  test.describe.configure({ mode: "serial" });
+
+  test("covers organizations, billing tabs, checkout initialization, and callback states", async ({
+    page,
+  }) => {
+    await signInAnonymously(page);
+    const organizationName = await createOrganization(page);
+
+    await expect(page.getByText("Organization Billing")).toBeVisible();
+    await expect(page.getByText("Owners and admins can manage billing")).toBeVisible();
+
+    await page.getByRole("tab", { name: "Subscriptions" }).click();
+    await expect(page.getByText("Subscription Plans")).toBeVisible();
+    await expect(page.getByText("Better Auth Config Plans")).toBeVisible();
+    await expect(page.getByText("Trusted Server Operations")).toBeVisible();
+
+    let subscriptionInitializePayload: unknown;
+    await page.route("**/api/auth/paystack/initialize-transaction", async (route) => {
+      subscriptionInitializePayload = route.request().postDataJSON();
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          reference: "e2e_subscribe",
+          accessCode: "access_e2e",
+          redirect: false,
+        }),
+      });
+    });
+
+    await page.getByRole("combobox").first().click();
+    await page.getByRole("option", { name: organizationName }).click();
+    await page.getByLabel("Number of Seats").fill("5");
+    await page
+      .getByRole("button", { name: /Subscribe Now|Start \d+-Day Trial/ })
+      .first()
+      .click();
+
+    await expect
+      .poll(() => subscriptionInitializePayload)
+      .toMatchObject({
+        callbackURL: "http://localhost:3000/billing/paystack/callback",
+        quantity: 5,
+      });
+
+    await page.getByRole("tab", { name: "One-Time" }).click();
+    await expect(page.getByText("One-Time Payments")).toBeVisible();
+    await expect(page.getByText("Better Auth Config Products")).toBeVisible();
+    await expect(page.getByText("Paystack->DB Synced Products")).toBeVisible();
+
+    let productInitializePayload: unknown;
+    await page.unroute("**/api/auth/paystack/initialize-transaction");
+    await page.route("**/api/auth/paystack/initialize-transaction", async (route) => {
+      productInitializePayload = route.request().postDataJSON();
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          reference: "e2e_product",
+          accessCode: "access_e2e",
+          redirect: false,
+        }),
+      });
+    });
+
+    await page
+      .getByRole("button", { name: /Buy Now|Purchase/ })
+      .first()
+      .click();
+
+    await expect
+      .poll(() => productInitializePayload)
+      .toMatchObject({
+        callbackURL: "http://localhost:3000/billing/paystack/callback",
+      });
+    expect(productInitializePayload).toEqual(
+      expect.objectContaining({ product: expect.any(String) }),
+    );
+
+    await page.getByRole("tab", { name: "Transactions" }).click();
+    await expect(page.getByText("Transaction History")).toBeVisible();
+    await expect(page.getByText("Reference")).toBeVisible();
+    await expect(page.getByText("Billed To")).toBeVisible();
+
+    await page.goto("/billing/paystack/callback");
+
+    await expect(page.getByText("No reference provided.")).toBeVisible();
+  });
+});

--- a/examples/tanstack/e2e/home.spec.ts
+++ b/examples/tanstack/e2e/home.spec.ts
@@ -1,21 +1,18 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("Home Page", () => {
-  test("should display the navbar", async ({ page }) => {
+  test("should display the anonymous login experience", async ({ page }) => {
     await page.goto("/");
 
-    // Check for navbar brand
-    await expect(page.locator("nav")).toBeVisible();
-    await expect(page.getByText("Better Auth")).toBeVisible();
-    await expect(page.getByText("Paystack")).toBeVisible();
+    await expect(page.getByRole("heading", { name: /Better Auth \+ Paystack SDK/i })).toBeVisible();
+    await expect(page.getByText("Anonymous Login")).toBeVisible();
+    await expect(page.getByText("Secure Checkout")).toBeVisible();
   });
 
-  test("should have sign in buttons when not authenticated", async ({ page }) => {
+  test("should have anonymous sign in when not authenticated", async ({ page }) => {
     await page.goto("/");
 
-    await expect(page.getByRole("button", { name: "Guest Sign In" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Sign Up" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Login Anonymously" })).toBeVisible();
   });
 });
 
@@ -24,25 +21,26 @@ test.describe("Authentication Flow", () => {
     await page.goto("/");
 
     // Click guest sign in
-    await page.getByRole("button", { name: "Guest Sign In" }).click();
+    const signInButton = page.getByRole("button", { name: "Login Anonymously" });
+    await signInButton.click();
 
     // Should redirect to dashboard
-    await expect(page).toHaveURL(/.*dashboard/);
+    await expect(page).toHaveURL(/.*dashboard/, { timeout: 15_000 });
 
     // Should show dashboard content
-    await expect(page.getByRole("button", { name: "Dashboard" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
   });
 
   test("should sign out and return to home", async ({ page }) => {
     // First sign in
     await page.goto("/");
-    await page.getByRole("button", { name: "Guest Sign In" }).click();
-    await expect(page).toHaveURL(/.*dashboard/);
+    await page.getByRole("button", { name: "Login Anonymously" }).click();
+    await expect(page).toHaveURL(/.*dashboard/, { timeout: 15_000 });
 
     // Then sign out
     await page.getByRole("button", { name: "Sign Out" }).click();
 
     // Should return to home without session
-    await expect(page.getByRole("button", { name: "Guest Sign In" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Login Anonymously" })).toBeVisible();
   });
 });

--- a/examples/tanstack/package.json
+++ b/examples/tanstack/package.json
@@ -50,7 +50,8 @@
     "react-dom": "catalog:",
     "tailwind-merge": "catalog:",
     "tailwindcss": "catalog:",
-    "tw-animate-css": "catalog:"
+    "tw-animate-css": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@playwright/test": "catalog:",

--- a/examples/tanstack/playwright.config.ts
+++ b/examples/tanstack/playwright.config.ts
@@ -1,17 +1,16 @@
 import { defineConfig, devices } from "@playwright/test";
 
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: process.env.CI !== undefined && process.env.CI !== null && process.env.CI !== "",
   retries: process.env.CI !== undefined && process.env.CI !== null && process.env.CI !== "" ? 2 : 0,
-  workers:
-    process.env.CI !== undefined && process.env.CI !== null && process.env.CI !== ""
-      ? 1
-      : undefined,
+  workers: 1,
   reporter: "html",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL,
     trace: "on-first-retry",
   },
   projects: [
@@ -28,10 +27,13 @@ export default defineConfig({
       use: { ...devices["Desktop Safari"] },
     },
   ],
-  webServer: {
-    command: "pnpm dev",
-    url: "http://localhost:3000",
-    reuseExistingServer:
-      process.env.CI === undefined || process.env.CI === null || process.env.CI === "",
-  },
+  webServer:
+    process.env.PLAYWRIGHT_SKIP_WEB_SERVER === "1"
+      ? undefined
+      : {
+          command: "pnpm dev",
+          url: baseURL,
+          reuseExistingServer:
+            process.env.CI === undefined || process.env.CI === null || process.env.CI === "",
+        },
 });

--- a/examples/tanstack/public/robots.txt
+++ b/examples/tanstack/public/robots.txt
@@ -1,3 +1,0 @@
-# https://www.robotstxt.org/robotstxt.html
-User-agent: *
-Disallow:

--- a/examples/tanstack/src/__tests__/components/OrganizationManager.test.tsx
+++ b/examples/tanstack/src/__tests__/components/OrganizationManager.test.tsx
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import OrganizationManager from "@/components/dashboard/OrganizationManager";
+import { authClient } from "@/lib/auth-client";
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    organization: {
+      list: vi.fn(),
+      create: vi.fn(),
+      setActive: vi.fn(),
+      getFullOrganization: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@phosphor-icons/react", () => ({
+  Buildings: () => <div data-testid="icon-buildings" />,
+  Check: () => <div data-testid="icon-check" />,
+  Copy: () => <div data-testid="icon-copy" />,
+  CreditCard: () => <div data-testid="icon-credit-card" />,
+  Crown: () => <div data-testid="icon-crown" />,
+  Plus: () => <div data-testid="icon-plus" />,
+  Trash: () => <div data-testid="icon-trash" />,
+  UserCircle: () => <div data-testid="icon-user-circle" />,
+  Users: () => <div data-testid="icon-users" />,
+}));
+
+describe("OrganizationManager component", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(authClient.organization.list).mockResolvedValue({ data: [] } as never);
+    vi.mocked(authClient.organization.create).mockResolvedValue({
+      data: null,
+      error: null,
+    } as never);
+    vi.mocked(authClient.organization.setActive).mockResolvedValue({ data: null } as never);
+    vi.mocked(authClient.organization.getFullOrganization).mockResolvedValue({
+      data: { members: [] },
+    } as never);
+  });
+
+  it("creates an organization and selects it when Better Auth returns data", async () => {
+    const organization = {
+      id: "org_123",
+      name: "Acme Co",
+      slug: "acme-co",
+      createdAt: new Date(),
+    };
+
+    vi.mocked(authClient.organization.list)
+      .mockResolvedValueOnce({ data: [] } as never)
+      .mockResolvedValueOnce({ data: [organization] } as never);
+    vi.mocked(authClient.organization.create).mockResolvedValue({
+      data: organization,
+      error: null,
+    } as never);
+
+    render(<OrganizationManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText("New Organization")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("New Organization"));
+    fireEvent.change(screen.getByLabelText("Organization Name *"), {
+      target: { value: "Acme Co" },
+    });
+    fireEvent.click(screen.getByText("Create Organization"));
+
+    await waitFor(() => {
+      expect(authClient.organization.create).toHaveBeenCalledWith({
+        name: "Acme Co",
+        slug: "acme-co",
+      });
+      expect(screen.getByText("Acme Co")).toBeInTheDocument();
+      expect(screen.getByText("/acme-co")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Better Auth organization create errors instead of failing silently", async () => {
+    vi.mocked(authClient.organization.create).mockResolvedValue({
+      data: null,
+      error: { message: "Organization slug is already taken" },
+    } as never);
+
+    render(<OrganizationManager />);
+
+    await waitFor(() => {
+      expect(screen.getByText("New Organization")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("New Organization"));
+    fireEvent.change(screen.getByLabelText("Organization Name *"), {
+      target: { value: "Acme Co" },
+    });
+    fireEvent.click(screen.getByText("Create Organization"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Organization slug is already taken")).toBeInTheDocument();
+    });
+  });
+});

--- a/examples/tanstack/src/__tests__/components/PaymentManager.test.tsx
+++ b/examples/tanstack/src/__tests__/components/PaymentManager.test.tsx
@@ -123,6 +123,9 @@ describe("PaymentManager component", () => {
     vi.mocked((authClient as any).paystack.listProducts).mockResolvedValue({
       data: { products: [] },
     } as any);
+    vi.mocked((authClient as any).paystack.listPlans).mockResolvedValue({
+      data: { plans: [] },
+    } as any);
     vi.mocked((authClient as any).organization.list).mockResolvedValue({ data: [] } as any);
     syncProductsMock.mockResolvedValue({ status: "success", count: 2 });
     syncPlansMock.mockResolvedValue({ status: "success", count: 3 });
@@ -625,9 +628,9 @@ describe("PaymentManager component", () => {
           scheduleAtPeriodEnd: true,
         }),
       );
-      expect(window.alert).toHaveBeenCalledWith(
-        "Plan change scheduled for the end of the current billing period.",
-      );
+      expect(
+        screen.getByText("Plan change scheduled for the end of the current billing period."),
+      ).toBeInTheDocument();
     });
   });
 
@@ -675,9 +678,9 @@ describe("PaymentManager component", () => {
           prorateAndCharge: true,
         }),
       );
-      expect(window.alert).toHaveBeenCalledWith(
-        "Subscription successfully upgraded with prorated charge.",
-      );
+      expect(
+        screen.getByText("Subscription successfully upgraded with prorated charge."),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/examples/tanstack/src/__tests__/routes/paystack-callback.test.tsx
+++ b/examples/tanstack/src/__tests__/routes/paystack-callback.test.tsx
@@ -1,19 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { CallbackPage } from "@/routes/billing/paystack/callback";
 
-const { mockNavigate, mockUseSearch } = vi.hoisted(() => ({
-  mockNavigate: vi.fn(),
-  mockUseSearch: vi.fn(() => ({ reference: "ref_123" })),
+const { mockNavigate, mockUseSearch, verifyCallbackMock, verifyCallbackServerFnMock } = vi.hoisted(
+  () => ({
+    mockNavigate: vi.fn(),
+    mockUseSearch: vi.fn(() => ({ reference: "ref_123" })),
+    verifyCallbackMock: vi.fn(),
+    verifyCallbackServerFnMock: { __serverFn: "verifyPaystackCallback" },
+  }),
+);
+
+vi.mock("@/lib/paystack-admin", () => ({
+  verifyPaystackCallbackServerFn: verifyCallbackServerFnMock,
 }));
 
-vi.mock("@/lib/auth-client", () => ({
-  authClient: {
-    paystack: {
-      verifyTransaction: vi.fn(),
+vi.mock("@tanstack/react-start", async () => {
+  const actual = await vi.importActual<Record<string, unknown>>("@tanstack/react-start");
+
+  return {
+    ...actual,
+    useServerFn: (serverFn: { __serverFn?: string }) => {
+      if (serverFn.__serverFn === "verifyPaystackCallback") return verifyCallbackMock;
+      return vi.fn();
     },
-  },
-}));
+  };
+});
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<Record<string, unknown>>("@tanstack/react-router");
@@ -31,20 +43,12 @@ vi.mock("@tanstack/react-router", async () => {
 
 describe("Paystack callback route", () => {
   afterEach(() => {
-    vi.useRealTimers();
     vi.clearAllMocks();
     mockUseSearch.mockReturnValue({ reference: "ref_123" });
   });
 
-  it("shows an error when verifyTransaction returns a Better Auth error payload", async () => {
-    const { authClient } = await import("@/lib/auth-client");
-
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockResolvedValue({
-      data: null,
-      error: {
-        message: "Verification failed on the server",
-      },
-    } as any);
+  it("shows an error when server-side verification fails", async () => {
+    verifyCallbackMock.mockRejectedValue(new Error("Verification failed on the server"));
 
     render(<CallbackPage />);
 
@@ -56,52 +60,25 @@ describe("Paystack callback route", () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it("retries transient reference-not-found verification failures and accepts trxref", async () => {
-    vi.useFakeTimers();
+  it("accepts trxref and verifies through the server function", async () => {
     mockUseSearch.mockReturnValue({ trxref: "trx_123" } as any);
 
-    const { authClient } = await import("@/lib/auth-client");
-
-    let verifyCount = 0;
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockImplementation(() => {
-      verifyCount++;
-      if (verifyCount === 1) {
-        return Promise.resolve({
-          data: null,
-          error: {
-            message: "Transaction reference not found.",
-          },
-        } as any);
-      }
-      return Promise.resolve({
-        data: {
-          status: "success",
-        },
-        error: null,
-      } as any);
+    verifyCallbackMock.mockResolvedValue({
+      data: {
+        status: "success",
+      },
     });
 
     render(<CallbackPage />);
 
-    // Flush the initial effect and first verification promise.
-    await act(async () => {
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(verifyCallbackMock).toHaveBeenCalledWith({ data: { reference: "trx_123" } });
+      expect(screen.getByText("Payment Successful!")).toBeInTheDocument();
     });
-
-    // Trigger the retry delay and flush the second verification promise.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-      await Promise.resolve();
-    });
-
-    expect((authClient as any).paystack.verifyTransaction).toHaveBeenCalledTimes(2);
-    expect(screen.getByText("Payment Successful!")).toBeInTheDocument();
-  }, 20000);
+  });
 
   it("shows a trial-specific success state when the verified transaction metadata indicates a trial", async () => {
-    const { authClient } = await import("@/lib/auth-client");
-
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockResolvedValue({
+    verifyCallbackMock.mockResolvedValue({
       data: {
         status: "success",
         metadata: JSON.stringify({
@@ -109,8 +86,7 @@ describe("Paystack callback route", () => {
           plan: "business",
         }),
       },
-      error: null,
-    } as any);
+    });
 
     render(<CallbackPage />);
 
@@ -123,17 +99,14 @@ describe("Paystack callback route", () => {
   });
 
   it("shows a one-time purchase success state when product metadata is present", async () => {
-    const { authClient } = await import("@/lib/auth-client");
-
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockResolvedValue({
+    verifyCallbackMock.mockResolvedValue({
       data: {
         status: "success",
         metadata: JSON.stringify({
           product: "50 credits pack",
         }),
       },
-      error: null,
-    } as any);
+    });
 
     render(<CallbackPage />);
 
@@ -148,17 +121,14 @@ describe("Paystack callback route", () => {
   });
 
   it("shows an upgrade-specific success state for proration payments", async () => {
-    const { authClient } = await import("@/lib/auth-client");
-
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockResolvedValue({
+    verifyCallbackMock.mockResolvedValue({
       data: {
         status: "success",
         metadata: JSON.stringify({
           type: "proration",
         }),
       },
-      error: null,
-    } as any);
+    });
 
     render(<CallbackPage />);
 
@@ -171,9 +141,7 @@ describe("Paystack callback route", () => {
   });
 
   it("shows a friendly paid-activation message when a requested trial was already used", async () => {
-    const { authClient } = await import("@/lib/auth-client");
-
-    vi.mocked((authClient as any).paystack.verifyTransaction).mockResolvedValue({
+    verifyCallbackMock.mockResolvedValue({
       data: {
         status: "success",
         metadata: JSON.stringify({
@@ -183,8 +151,7 @@ describe("Paystack callback route", () => {
           trialDeniedReason: "already_used",
         }),
       },
-      error: null,
-    } as any);
+    });
 
     render(<CallbackPage />);
 

--- a/examples/tanstack/src/components/dashboard/OrganizationManager.tsx
+++ b/examples/tanstack/src/components/dashboard/OrganizationManager.tsx
@@ -48,6 +48,7 @@ export default function OrganizationManager() {
   const [creating, setCreating] = useState(false);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ tone: "error" | "success"; text: string } | null>(null);
 
   // Form state
   const [orgName, setOrgName] = useState("");
@@ -113,16 +114,25 @@ export default function OrganizationManager() {
         slug,
       });
 
+      if (result.error !== null && result.error !== undefined) {
+        setMessage({
+          tone: "error",
+          text: result.error.message ?? "Failed to create organization",
+        });
+        return;
+      }
+
       if (result.data !== null && result.data !== undefined) {
         await loadOrganizations();
         setActiveOrg(result.data as Organization);
         setOrgName("");
         setOrgSlug("");
         setShowCreateForm(false);
+        setMessage({ tone: "success", text: "Organization created." });
       }
     } catch (error: unknown) {
       const message = (error as { message?: string })?.message ?? "Failed to create organization";
-      alert(message);
+      setMessage({ tone: "error", text: message });
     } finally {
       setCreating(false);
     }
@@ -200,6 +210,17 @@ export default function OrganizationManager() {
 
         {showCreateForm && (
           <CardContent>
+            {message !== null && (
+              <div
+                className={`mb-4 rounded-lg border px-3 py-2 text-sm ${
+                  message.tone === "error"
+                    ? "border-red-200 bg-red-50 text-red-700"
+                    : "border-emerald-200 bg-emerald-50 text-emerald-700"
+                }`}
+              >
+                {message.text}
+              </div>
+            )}
             <form
               onSubmit={(e) => {
                 void createOrganization(e);

--- a/examples/tanstack/src/components/dashboard/PaymentManager.tsx
+++ b/examples/tanstack/src/components/dashboard/PaymentManager.tsx
@@ -13,6 +13,7 @@ import {
   User,
 } from "@phosphor-icons/react";
 import { authClient } from "@/lib/auth-client";
+import { paystackActions, subscriptionActions } from "@/lib/paystack-client";
 import {
   chargeRenewalServerFn,
   syncPlansServerFn,
@@ -53,6 +54,19 @@ interface RenewalResult {
   reference: string | null;
 }
 
+interface OperationMessage {
+  tone: "success" | "error" | "info";
+  text: string;
+}
+
+function getErrorMessage(error: unknown, fallback: string) {
+  return error instanceof Error && error.message !== "" ? error.message : fallback;
+}
+
+function getProductPrice(product: PaystackProduct & { amount?: number }) {
+  return product.price ?? product.amount;
+}
+
 export default function PaymentManager({ activeTab }: { activeTab: "subscriptions" | "one-time" }) {
   const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
   const [config, setConfig] = useState<{
@@ -66,6 +80,7 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
   const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [selectedBillingTarget, setSelectedBillingTarget] = useState<string>("personal"); // "personal" or org.id
   const [quantity, setQuantity] = useState(1);
+  const [actionMessage, setActionMessage] = useState<OperationMessage | null>(null);
   const [serverOpsMessage, setServerOpsMessage] = useState<string | null>(null);
   const [serverOpsLoading, setServerOpsLoading] = useState<null | "plans" | "products" | "renewal">(
     null,
@@ -105,23 +120,29 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const fetchNativeProducts = useCallback(async () => {
     try {
-      const res = await (authClient as any).paystack.listProducts();
+      const res = await paystackActions.listProducts();
       if (res.data?.products !== undefined && res.data?.products !== null) {
         setNativeProducts(res.data.products as unknown as PaystackProduct[]);
       }
-    } catch (_) {
-      // Silently fail
+    } catch (error: unknown) {
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(error, "Failed to load synced products."),
+      });
     }
   }, []);
 
   const fetchNativePlans = useCallback(async () => {
     try {
-      const res = await (authClient as any).paystack.listPlans();
+      const res = await paystackActions.listPlans();
       if (res.data?.plans !== undefined && res.data?.plans !== null) {
         setNativePlans(res.data.plans as PaystackPlan[]);
       }
-    } catch (_) {
-      // Silently fail
+    } catch (error: unknown) {
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(error, "Failed to load synced plans."),
+      });
     }
   }, []);
 
@@ -130,8 +151,8 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
       setIsLoading(true);
       try {
         const [configRes, subsRes] = await Promise.all([
-          (authClient as any).paystack.config(),
-          authClient.subscription.list({
+          paystackActions.config(),
+          subscriptionActions.list({
             query: {
               referenceId: selectedBillingTarget !== "personal" ? selectedBillingTarget : undefined,
             },
@@ -149,8 +170,11 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         if (subsRes.data?.subscriptions !== undefined && subsRes.data?.subscriptions !== null) {
           setSubscriptions(subsRes.data.subscriptions);
         }
-      } catch (_) {
-        // Silently fail
+      } catch (error: unknown) {
+        setActionMessage({
+          tone: "error",
+          text: getErrorMessage(error, "Failed to load billing details."),
+        });
       } finally {
         setIsLoading(false);
       }
@@ -168,8 +192,11 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         if (result.data !== undefined && result.data !== null) {
           setOrganizations(result.data as Organization[]);
         }
-      } catch (_) {
-        // Silently fail
+      } catch (error: unknown) {
+        setActionMessage({
+          tone: "error",
+          text: getErrorMessage(error, "Failed to load organizations."),
+        });
       }
     }
     void fetchOrganizations();
@@ -190,6 +217,7 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const handleSubscribe = async (planName: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
       const initPayload: {
         plan: string;
@@ -207,25 +235,27 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         initPayload.referenceId = selectedBillingTarget;
         // Add quantity/seats for organization billing
         if (quantity > 1) {
-          (initPayload as Record<string, unknown>).quantity = quantity;
+          initPayload.quantity = quantity;
         }
       }
-      const res = await (authClient as any).paystack.initializeTransaction(initPayload);
+      const res = await paystackActions.initializeTransaction(initPayload);
       if (typeof res.data?.url === "string") {
         window.location.href = res.data.url;
       } else {
-        alert("Failed to get redirect URL from Paystack");
+        setActionMessage({ tone: "error", text: "Failed to get redirect URL from Paystack." });
       }
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to initialize payment");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to initialize payment."),
+      });
       setActionLoading(false);
     }
   };
 
   const handleSchedulePlanChange = async (planName: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
       const payload: {
         plan: string;
@@ -242,12 +272,16 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         payload.referenceId = selectedBillingTarget;
       }
 
-      await (authClient as any).paystack.initializeTransaction(payload);
-      alert("Plan change scheduled for the end of the current billing period.");
+      await paystackActions.initializeTransaction(payload);
+      setActionMessage({
+        tone: "success",
+        text: "Plan change scheduled for the end of the current billing period.",
+      });
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to schedule plan change");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to schedule plan change."),
+      });
     } finally {
       setActionLoading(false);
     }
@@ -255,6 +289,7 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const handleUpgradeNow = async (planName: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
       const payload: {
         plan: string;
@@ -275,7 +310,7 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         }
       }
 
-      const res = await (authClient as any).paystack.initializeTransaction(payload);
+      const res = await paystackActions.initializeTransaction(payload);
       if (typeof res.data?.url === "string") {
         window.location.href = res.data.url;
       } else if (res.data?.prorated === true) {
@@ -293,14 +328,21 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
               : subscription,
           ),
         );
-        alert(res.data?.message ?? "Subscription upgraded with proration.");
+        setActionMessage({
+          tone: "success",
+          text: res.data?.message ?? "Subscription upgraded with proration.",
+        });
       } else {
-        alert(res.data?.message ?? "Upgrade processed successfully.");
+        setActionMessage({
+          tone: "success",
+          text: res.data?.message ?? "Upgrade processed successfully.",
+        });
       }
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to upgrade subscription");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to upgrade subscription."),
+      });
     } finally {
       setActionLoading(false);
     }
@@ -308,10 +350,11 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const handleBuyProduct = async (product: PaystackProduct) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
       const metadata =
         typeof product.metadata === "string" ? JSON.parse(product.metadata) : product.metadata;
-      const res = await (authClient as any).paystack.initializeTransaction({
+      const res = await paystackActions.initializeTransaction({
         product: product.name,
         amount: product.price ?? 0,
         currency: product.currency ?? "NGN",
@@ -321,29 +364,37 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
       if (typeof res.data?.url === "string") {
         window.location.href = res.data.url;
       } else {
-        alert("Failed to get redirect URL from Paystack");
+        setActionMessage({ tone: "error", text: "Failed to get redirect URL from Paystack." });
       }
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to initialize payment");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to initialize payment."),
+      });
       setActionLoading(false);
     }
   };
 
   const handleManageBilling = async (subscriptionCode: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
-      const res = await authClient.subscription.billingPortal({
+      const res = await subscriptionActions.billingPortal({
         subscriptionCode,
       });
       if (res.data?.link !== undefined && res.data?.link !== null && res.data.link !== "") {
         window.location.href = res.data.link;
       } else {
-        alert("Failed to get management link from Paystack");
+        setActionMessage({
+          tone: "error",
+          text: "Failed to get management link from Paystack.",
+        });
       }
-    } catch (_) {
-      // Silently fail, alert handles it for user
+    } catch (error: unknown) {
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(error, "Failed to get management link from Paystack."),
+      });
     } finally {
       setActionLoading(false);
     }
@@ -351,8 +402,9 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const handleCancelSubscription = async (subscriptionCode: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
-      await authClient.subscription.cancel({
+      await subscriptionActions.cancel({
         subscriptionCode,
         atPeriodEnd: true,
       });
@@ -364,9 +416,10 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         ),
       );
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to schedule cancellation");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to schedule cancellation."),
+      });
     } finally {
       setActionLoading(false);
     }
@@ -374,8 +427,9 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
 
   const handleRestoreSubscription = async (subscriptionCode: string) => {
     setActionLoading(true);
+    setActionMessage(null);
     try {
-      await authClient.subscription.restore({
+      await subscriptionActions.restore({
         subscriptionCode,
       });
       setSubscriptions((current) =>
@@ -386,9 +440,10 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         ),
       );
     } catch (e: unknown) {
-      if (e instanceof Error) {
-        alert(e.message || "Failed to restore subscription");
-      }
+      setActionMessage({
+        tone: "error",
+        text: getErrorMessage(e, "Failed to restore subscription."),
+      });
     } finally {
       setActionLoading(false);
     }
@@ -488,6 +543,20 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
           </div>
         </CardHeader>
         <CardContent className="space-y-8">
+          {actionMessage !== null && (
+            <div
+              className={cn(
+                "rounded-lg border px-3 py-2 text-xs",
+                actionMessage.tone === "error" && "border-red-200 bg-red-50 text-red-700",
+                actionMessage.tone === "success" &&
+                  "border-emerald-200 bg-emerald-50 text-emerald-700",
+                actionMessage.tone === "info" && "border-blue-200 bg-blue-50 text-blue-700",
+              )}
+            >
+              {actionMessage.text}
+            </div>
+          )}
+
           {/* Active Subscription Summary */}
           {activeSubscription && (
             <div className="p-4 bg-primary/5 border border-primary/20 rounded-xl flex items-center justify-between">
@@ -778,6 +847,20 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
         </p>
       </CardHeader>
       <CardContent className="space-y-4">
+        {actionMessage !== null && (
+          <div
+            className={cn(
+              "rounded-lg border px-3 py-2 text-xs",
+              actionMessage.tone === "error" && "border-red-200 bg-red-50 text-red-700",
+              actionMessage.tone === "success" &&
+                "border-emerald-200 bg-emerald-50 text-emerald-700",
+              actionMessage.tone === "info" && "border-blue-200 bg-blue-50 text-blue-700",
+            )}
+          >
+            {actionMessage.text}
+          </div>
+        )}
+
         <div className="space-y-6">
           <div className="space-y-4">
             <div>
@@ -799,10 +882,7 @@ export default function PaymentManager({ activeTab }: { activeTab: "subscription
                         <p className="text-xs text-muted-foreground">One-time payment</p>
                       </div>
                       <Badge variant="outline" className="text-primary border-primary/20">
-                        {formatCurrency(
-                          (product as any).price ?? (product as any).amount,
-                          product.currency,
-                        )}
+                        {formatCurrency(getProductPrice(product), product.currency)}
                       </Badge>
                     </div>
                     <Button

--- a/examples/tanstack/src/lib/agent-discovery.ts
+++ b/examples/tanstack/src/lib/agent-discovery.ts
@@ -1,0 +1,218 @@
+const publicPages = ["/", "/billing/paystack/callback"] as const;
+
+export const linkHeader =
+  '</.well-known/api-catalog>; rel="api-catalog", </openapi.json>; rel="service-desc"; type="application/vnd.oai.openapi+json", </api/health>; rel="status", <https://github.com/alexasomba/better-auth-paystack#readme>; rel="service-doc"';
+
+export const homeMarkdown = `# Better Auth Paystack TanStack Start Example
+
+This example demonstrates Better Auth anonymous sessions with Paystack billing flows.
+
+## Public Pages
+
+- Home: anonymous sign-in entry point.
+- Paystack callback: payment verification return path.
+
+## Agent Resources
+
+- API catalog: /.well-known/api-catalog
+- OpenAPI description: /openapi.json
+- Health endpoint: /api/health
+- Sitemap: /sitemap.xml
+`;
+
+export const paystackSkillMarkdown = `# better-auth-paystack-demo
+
+Use this site to inspect the Better Auth Paystack TanStack Start demo.
+
+## Resources
+
+- API catalog: /.well-known/api-catalog
+- OpenAPI description: /openapi.json
+- Health endpoint: /api/health
+- Sitemap: /sitemap.xml
+
+## Actions
+
+- Visit / to start an anonymous Better Auth session.
+- Visit /dashboard after signing in to manage demo billing workflows.
+`;
+
+export function getOrigin(request: Request) {
+  return new URL(request.url).origin;
+}
+
+export function absoluteUrl(origin: string, path: string) {
+  return new URL(path, origin).toString();
+}
+
+export function getSitemapXml(origin: string) {
+  const urls = publicPages
+    .map((path) => {
+      return `  <url>
+    <loc>${absoluteUrl(origin, path)}</loc>
+  </url>`;
+    })
+    .join("\n");
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+export function getOpenApiDocument(origin: string) {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Better Auth Paystack TanStack Example API",
+      version: "1.0.0",
+      description: "Discovery metadata for the Better Auth Paystack TanStack Start example.",
+    },
+    servers: [{ url: origin }],
+    paths: {
+      "/api/health": {
+        get: {
+          summary: "Health check",
+          responses: {
+            "200": {
+              description: "The example application is available.",
+            },
+          },
+        },
+      },
+      "/api/auth/{path}": {
+        get: {
+          summary: "Better Auth endpoint",
+          parameters: [
+            {
+              name: "path",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Better Auth response.",
+            },
+          },
+        },
+        post: {
+          summary: "Better Auth endpoint",
+          parameters: [
+            {
+              name: "path",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Better Auth response.",
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function getApiCatalog(origin: string) {
+  return {
+    linkset: [
+      {
+        anchor: absoluteUrl(origin, "/api"),
+        "service-desc": [
+          {
+            href: absoluteUrl(origin, "/openapi.json"),
+            type: "application/vnd.oai.openapi+json",
+          },
+        ],
+        "service-doc": [
+          {
+            href: "https://github.com/alexasomba/better-auth-paystack#readme",
+            type: "text/html",
+          },
+        ],
+        status: [
+          {
+            href: absoluteUrl(origin, "/api/health"),
+            type: "application/json",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function getOidcConfiguration(origin: string) {
+  return {
+    issuer: origin,
+    authorization_endpoint: absoluteUrl(origin, "/api/auth/sign-in"),
+    token_endpoint: absoluteUrl(origin, "/api/auth/token"),
+    jwks_uri: absoluteUrl(origin, "/api/auth/jwks"),
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
+    scopes_supported: ["openid", "profile", "email"],
+    subject_types_supported: ["public"],
+    id_token_signing_alg_values_supported: ["RS256"],
+  };
+}
+
+export function getOAuthProtectedResource(origin: string) {
+  return {
+    resource: absoluteUrl(origin, "/api"),
+    authorization_servers: [origin],
+    scopes_supported: ["openid", "profile", "email"],
+  };
+}
+
+export function getMcpServerCard(origin: string) {
+  return {
+    serverInfo: {
+      name: "better-auth-paystack-tanstack-example",
+      version: "1.0.0",
+    },
+    transport: {
+      type: "streamable-http",
+      endpoint: absoluteUrl(origin, "/mcp"),
+    },
+    capabilities: {
+      tools: {
+        listChanged: false,
+      },
+      resources: {},
+      prompts: {},
+    },
+  };
+}
+
+export async function getAgentSkillsIndex(origin: string) {
+  const digest = await sha256(paystackSkillMarkdown);
+
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills: [
+      {
+        name: "better-auth-paystack-demo",
+        type: "skill-md",
+        description:
+          "Inspect the Better Auth Paystack TanStack Start demo and its discovery resources.",
+        url: absoluteUrl(origin, "/.well-known/agent-skills/better-auth-paystack-demo/SKILL.md"),
+        digest: `sha256:${digest}`,
+      },
+    ],
+  };
+}
+
+export function markdownTokenCount(markdown: string) {
+  return markdown.trim().split(/\s+/u).filter(Boolean).length.toString();
+}
+
+async function sha256(value: string) {
+  const bytes = new TextEncoder().encode(value);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(hashBuffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/examples/tanstack/src/lib/auth.ts
+++ b/examples/tanstack/src/lib/auth.ts
@@ -30,7 +30,7 @@ export const data: Record<string, unknown[]> = {
 const memory = memoryAdapter(data);
 
 const baseURL =
-  process.env.BETTER_AUTH_URL ?? process.env.VITE_BETTER_AUTH_URL ?? "http://localhost:8787";
+  process.env.BETTER_AUTH_URL ?? process.env.VITE_BETTER_AUTH_URL ?? "http://localhost:3000";
 
 const secretKey = process.env.PAYSTACK_SECRET_KEY;
 const webhookSecret = process.env.PAYSTACK_WEBHOOK_SECRET;

--- a/examples/tanstack/src/lib/auth.ts
+++ b/examples/tanstack/src/lib/auth.ts
@@ -46,6 +46,14 @@ export const paystackClient =
   secretKey !== undefined && secretKey !== null && secretKey !== ""
     ? createPaystack({
         secretKey,
+        timeoutMs: 30_000,
+        retry: {
+          retries: 3,
+          minDelayMs: 500,
+          maxDelayMs: 5_000,
+          retryOnStatuses: [408, 429, 500, 502, 503, 504],
+        },
+        idempotencyKey: "auto",
       })
     : null;
 

--- a/examples/tanstack/src/lib/paystack-admin.ts
+++ b/examples/tanstack/src/lib/paystack-admin.ts
@@ -1,11 +1,47 @@
 import { createServerFn } from "@tanstack/react-start";
 import { getRequestHeaders } from "@tanstack/react-start/server";
+import { z } from "zod";
+import type { GenericEndpointContext } from "better-auth";
 import {
   chargeSubscriptionRenewal,
   syncPaystackPlans,
   syncPaystackProducts,
+  type PaystackTransactionResponse,
 } from "@alexasomba/better-auth-paystack";
 import { auth, paystackOptions } from "@/lib/auth";
+
+const renewalInputSchema = z.object({
+  subscriptionId: z.string().min(1),
+});
+
+const verifyCallbackInputSchema = z.object({
+  reference: z.string().min(1),
+});
+
+type VerifyCallbackResult = {
+  status: string;
+  reference: string;
+  data: PaystackTransactionResponse;
+};
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (
+    error !== null &&
+    typeof error === "object" &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  return "Paystack operation failed.";
+}
+
+function hasBillingRole(role: unknown): boolean {
+  const roles = Array.isArray(role) ? role : typeof role === "string" ? role.split(",") : [];
+  return roles.some((value) => value === "owner" || value === "admin");
+}
 
 function requirePaystackOptions(): NonNullable<typeof paystackOptions> {
   if (paystackOptions === null) {
@@ -16,34 +52,34 @@ function requirePaystackOptions(): NonNullable<typeof paystackOptions> {
 }
 
 async function getAuthenticatedContext() {
-  const headers = getRequestHeaders();
+  const headers = await getRequestHeaders();
   const session = await auth.api.getSession({ headers });
 
   if (session?.user === undefined || session.user === null) {
     throw new Error("You must be signed in to run trusted billing operations.");
   }
 
-  const ctx = { context: await auth.$context } as any;
+  const ctx = { context: await auth.$context } as GenericEndpointContext;
 
   return { ctx, session };
 }
 
 export const syncProductsServerFn = createServerFn({ method: "POST" })
-  .inputValidator(() => undefined)
+  .inputValidator(z.void())
   .handler(async () => {
     const { ctx } = await getAuthenticatedContext();
     return syncPaystackProducts(ctx, requirePaystackOptions());
   });
 
 export const syncPlansServerFn = createServerFn({ method: "POST" })
-  .inputValidator(() => undefined)
+  .inputValidator(z.void())
   .handler(async () => {
     const { ctx } = await getAuthenticatedContext();
     return syncPaystackPlans(ctx, requirePaystackOptions());
   });
 
 export const chargeRenewalServerFn = createServerFn({ method: "POST" })
-  .inputValidator((data: { subscriptionId: string }) => data)
+  .inputValidator(renewalInputSchema)
   .handler(async (serverCtx) => {
     const input = serverCtx.data;
     const { ctx, session } = await getAuthenticatedContext();
@@ -69,6 +105,10 @@ export const chargeRenewalServerFn = createServerFn({ method: "POST" })
       if (member === undefined || member === null) {
         throw new Error("You are not allowed to manage this billing profile.");
       }
+
+      if (!hasBillingRole((member as { role?: unknown }).role)) {
+        throw new Error("Only organization owners and admins can manage billing.");
+      }
     }
 
     const result = await chargeSubscriptionRenewal(ctx, requirePaystackOptions(), {
@@ -79,4 +119,34 @@ export const chargeRenewalServerFn = createServerFn({ method: "POST" })
       status: result.status,
       reference: result.data.reference ?? null,
     };
+  });
+
+export const verifyPaystackCallbackServerFn = createServerFn({ method: "POST" })
+  .inputValidator(verifyCallbackInputSchema)
+  .handler(async ({ data }) => {
+    const headers = await getRequestHeaders();
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < 4; attempt++) {
+      try {
+        return (await auth.api.verifyTransaction({
+          body: { reference: data.reference },
+          headers,
+        })) as VerifyCallbackResult;
+      } catch (error: unknown) {
+        lastError = error;
+        const message = getErrorMessage(error);
+        const shouldRetry = message.includes("Transaction reference not found") && attempt < 3;
+
+        if (!shouldRetry) {
+          throw new Error(message);
+        }
+
+        await new Promise((resolve) => {
+          setTimeout(resolve, 750);
+        });
+      }
+    }
+
+    throw new Error(getErrorMessage(lastError));
   });

--- a/examples/tanstack/src/lib/paystack-client.ts
+++ b/examples/tanstack/src/lib/paystack-client.ts
@@ -1,0 +1,12 @@
+import { authClient } from "@/lib/auth-client";
+import type { PaystackClientActions } from "@alexasomba/better-auth-paystack/client";
+
+type BetterAuthPaystackClient = {
+  paystack: PaystackClientActions;
+  subscription: PaystackClientActions["subscription"];
+};
+
+const billingAuthClient = authClient as typeof authClient & BetterAuthPaystackClient;
+
+export const paystackActions = billingAuthClient.paystack;
+export const subscriptionActions = billingAuthClient.subscription;

--- a/examples/tanstack/src/routeTree.gen.ts
+++ b/examples/tanstack/src/routeTree.gen.ts
@@ -8,261 +8,262 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as SitemapDotxmlRouteImport } from "./routes/sitemap[.]xml";
-import { Route as RobotsDottxtRouteImport } from "./routes/robots[.]txt";
-import { Route as OpenapiDotjsonRouteImport } from "./routes/openapi[.]json";
-import { Route as McpRouteImport } from "./routes/mcp";
-import { Route as DashboardRouteImport } from "./routes/dashboard";
-import { Route as BillingRouteImport } from "./routes/billing";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as ApiHealthRouteImport } from "./routes/api/health";
-import { Route as DotwellKnownSplatRouteImport } from "./routes/[.]well-known/$";
-import { Route as BillingPaystackCallbackRouteImport } from "./routes/billing/paystack/callback";
-import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
+import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
+import { Route as OpenapiDotjsonRouteImport } from './routes/openapi[.]json'
+import { Route as McpRouteImport } from './routes/mcp'
+import { Route as DashboardRouteImport } from './routes/dashboard'
+import { Route as BillingRouteImport } from './routes/billing'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as DotwellKnownSplatRouteImport } from './routes/[.]well-known/$'
+import { Route as BillingPaystackCallbackRouteImport } from './routes/billing/paystack/callback'
+import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
 
 const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
-  id: "/sitemap.xml",
-  path: "/sitemap.xml",
+  id: '/sitemap.xml',
+  path: '/sitemap.xml',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
-  id: "/robots.txt",
-  path: "/robots.txt",
+  id: '/robots.txt',
+  path: '/robots.txt',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const OpenapiDotjsonRoute = OpenapiDotjsonRouteImport.update({
-  id: "/openapi.json",
-  path: "/openapi.json",
+  id: '/openapi.json',
+  path: '/openapi.json',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const McpRoute = McpRouteImport.update({
-  id: "/mcp",
-  path: "/mcp",
+  id: '/mcp',
+  path: '/mcp',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
-  id: "/dashboard",
-  path: "/dashboard",
+  id: '/dashboard',
+  path: '/dashboard',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingRoute = BillingRouteImport.update({
-  id: "/billing",
-  path: "/billing",
+  id: '/billing',
+  path: '/billing',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
-  id: "/api/health",
-  path: "/api/health",
+  id: '/api/health',
+  path: '/api/health',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DotwellKnownSplatRoute = DotwellKnownSplatRouteImport.update({
-  id: "/.well-known/$",
-  path: "/.well-known/$",
+  id: '/.well-known/$',
+  path: '/.well-known/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const BillingPaystackCallbackRoute = BillingPaystackCallbackRouteImport.update({
-  id: "/paystack/callback",
-  path: "/paystack/callback",
+  id: '/paystack/callback',
+  path: '/paystack/callback',
   getParentRoute: () => BillingRoute,
-} as any);
+} as any)
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: "/api/auth/$",
-  path: "/api/auth/$",
+  id: '/api/auth/$',
+  path: '/api/auth/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRouteWithChildren;
-  "/dashboard": typeof DashboardRoute;
-  "/mcp": typeof McpRoute;
-  "/openapi.json": typeof OpenapiDotjsonRoute;
-  "/robots.txt": typeof RobotsDottxtRoute;
-  "/sitemap.xml": typeof SitemapDotxmlRoute;
-  "/.well-known/$": typeof DotwellKnownSplatRoute;
-  "/api/health": typeof ApiHealthRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRouteWithChildren
+  '/dashboard': typeof DashboardRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRouteWithChildren;
-  "/dashboard": typeof DashboardRoute;
-  "/mcp": typeof McpRoute;
-  "/openapi.json": typeof OpenapiDotjsonRoute;
-  "/robots.txt": typeof RobotsDottxtRoute;
-  "/sitemap.xml": typeof SitemapDotxmlRoute;
-  "/.well-known/$": typeof DotwellKnownSplatRoute;
-  "/api/health": typeof ApiHealthRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRouteWithChildren
+  '/dashboard': typeof DashboardRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/billing": typeof BillingRouteWithChildren;
-  "/dashboard": typeof DashboardRoute;
-  "/mcp": typeof McpRoute;
-  "/openapi.json": typeof OpenapiDotjsonRoute;
-  "/robots.txt": typeof RobotsDottxtRoute;
-  "/sitemap.xml": typeof SitemapDotxmlRoute;
-  "/.well-known/$": typeof DotwellKnownSplatRoute;
-  "/api/health": typeof ApiHealthRoute;
-  "/api/auth/$": typeof ApiAuthSplatRoute;
-  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/billing': typeof BillingRouteWithChildren
+  '/dashboard': typeof DashboardRoute
+  '/mcp': typeof McpRoute
+  '/openapi.json': typeof OpenapiDotjsonRoute
+  '/robots.txt': typeof RobotsDottxtRoute
+  '/sitemap.xml': typeof SitemapDotxmlRoute
+  '/.well-known/$': typeof DotwellKnownSplatRoute
+  '/api/health': typeof ApiHealthRoute
+  '/api/auth/$': typeof ApiAuthSplatRoute
+  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/billing"
-    | "/dashboard"
-    | "/mcp"
-    | "/openapi.json"
-    | "/robots.txt"
-    | "/sitemap.xml"
-    | "/.well-known/$"
-    | "/api/health"
-    | "/api/auth/$"
-    | "/billing/paystack/callback";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/billing'
+    | '/dashboard'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/api/health'
+    | '/api/auth/$'
+    | '/billing/paystack/callback'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/billing"
-    | "/dashboard"
-    | "/mcp"
-    | "/openapi.json"
-    | "/robots.txt"
-    | "/sitemap.xml"
-    | "/.well-known/$"
-    | "/api/health"
-    | "/api/auth/$"
-    | "/billing/paystack/callback";
+    | '/'
+    | '/billing'
+    | '/dashboard'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/api/health'
+    | '/api/auth/$'
+    | '/billing/paystack/callback'
   id:
-    | "__root__"
-    | "/"
-    | "/billing"
-    | "/dashboard"
-    | "/mcp"
-    | "/openapi.json"
-    | "/robots.txt"
-    | "/sitemap.xml"
-    | "/.well-known/$"
-    | "/api/health"
-    | "/api/auth/$"
-    | "/billing/paystack/callback";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/billing'
+    | '/dashboard'
+    | '/mcp'
+    | '/openapi.json'
+    | '/robots.txt'
+    | '/sitemap.xml'
+    | '/.well-known/$'
+    | '/api/health'
+    | '/api/auth/$'
+    | '/billing/paystack/callback'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  BillingRoute: typeof BillingRouteWithChildren;
-  DashboardRoute: typeof DashboardRoute;
-  McpRoute: typeof McpRoute;
-  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute;
-  RobotsDottxtRoute: typeof RobotsDottxtRoute;
-  SitemapDotxmlRoute: typeof SitemapDotxmlRoute;
-  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute;
-  ApiHealthRoute: typeof ApiHealthRoute;
-  ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
+  IndexRoute: typeof IndexRoute
+  BillingRoute: typeof BillingRouteWithChildren
+  DashboardRoute: typeof DashboardRoute
+  McpRoute: typeof McpRoute
+  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute
+  RobotsDottxtRoute: typeof RobotsDottxtRoute
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
+  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute
+  ApiHealthRoute: typeof ApiHealthRoute
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/sitemap.xml": {
-      id: "/sitemap.xml";
-      path: "/sitemap.xml";
-      fullPath: "/sitemap.xml";
-      preLoaderRoute: typeof SitemapDotxmlRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/robots.txt": {
-      id: "/robots.txt";
-      path: "/robots.txt";
-      fullPath: "/robots.txt";
-      preLoaderRoute: typeof RobotsDottxtRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/openapi.json": {
-      id: "/openapi.json";
-      path: "/openapi.json";
-      fullPath: "/openapi.json";
-      preLoaderRoute: typeof OpenapiDotjsonRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/mcp": {
-      id: "/mcp";
-      path: "/mcp";
-      fullPath: "/mcp";
-      preLoaderRoute: typeof McpRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/dashboard": {
-      id: "/dashboard";
-      path: "/dashboard";
-      fullPath: "/dashboard";
-      preLoaderRoute: typeof DashboardRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing": {
-      id: "/billing";
-      path: "/billing";
-      fullPath: "/billing";
-      preLoaderRoute: typeof BillingRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/health": {
-      id: "/api/health";
-      path: "/api/health";
-      fullPath: "/api/health";
-      preLoaderRoute: typeof ApiHealthRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/.well-known/$": {
-      id: "/.well-known/$";
-      path: "/.well-known/$";
-      fullPath: "/.well-known/$";
-      preLoaderRoute: typeof DotwellKnownSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/billing/paystack/callback": {
-      id: "/billing/paystack/callback";
-      path: "/paystack/callback";
-      fullPath: "/billing/paystack/callback";
-      preLoaderRoute: typeof BillingPaystackCallbackRouteImport;
-      parentRoute: typeof BillingRoute;
-    };
-    "/api/auth/$": {
-      id: "/api/auth/$";
-      path: "/api/auth/$";
-      fullPath: "/api/auth/$";
-      preLoaderRoute: typeof ApiAuthSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/sitemap.xml': {
+      id: '/sitemap.xml'
+      path: '/sitemap.xml'
+      fullPath: '/sitemap.xml'
+      preLoaderRoute: typeof SitemapDotxmlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/robots.txt': {
+      id: '/robots.txt'
+      path: '/robots.txt'
+      fullPath: '/robots.txt'
+      preLoaderRoute: typeof RobotsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/openapi.json': {
+      id: '/openapi.json'
+      path: '/openapi.json'
+      fullPath: '/openapi.json'
+      preLoaderRoute: typeof OpenapiDotjsonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/mcp': {
+      id: '/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/dashboard': {
+      id: '/dashboard'
+      path: '/dashboard'
+      fullPath: '/dashboard'
+      preLoaderRoute: typeof DashboardRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing': {
+      id: '/billing'
+      path: '/billing'
+      fullPath: '/billing'
+      preLoaderRoute: typeof BillingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/health': {
+      id: '/api/health'
+      path: '/api/health'
+      fullPath: '/api/health'
+      preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/.well-known/$': {
+      id: '/.well-known/$'
+      path: '/.well-known/$'
+      fullPath: '/.well-known/$'
+      preLoaderRoute: typeof DotwellKnownSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/billing/paystack/callback': {
+      id: '/billing/paystack/callback'
+      path: '/paystack/callback'
+      fullPath: '/billing/paystack/callback'
+      preLoaderRoute: typeof BillingPaystackCallbackRouteImport
+      parentRoute: typeof BillingRoute
+    }
+    '/api/auth/$': {
+      id: '/api/auth/$'
+      path: '/api/auth/$'
+      fullPath: '/api/auth/$'
+      preLoaderRoute: typeof ApiAuthSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 interface BillingRouteChildren {
-  BillingPaystackCallbackRoute: typeof BillingPaystackCallbackRoute;
+  BillingPaystackCallbackRoute: typeof BillingPaystackCallbackRoute
 }
 
 const BillingRouteChildren: BillingRouteChildren = {
   BillingPaystackCallbackRoute: BillingPaystackCallbackRoute,
-};
+}
 
-const BillingRouteWithChildren = BillingRoute._addFileChildren(BillingRouteChildren);
+const BillingRouteWithChildren =
+  BillingRoute._addFileChildren(BillingRouteChildren)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -275,17 +276,17 @@ const rootRouteChildren: RootRouteChildren = {
   DotwellKnownSplatRoute: DotwellKnownSplatRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { startInstance } from "./start.ts";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { startInstance } from './start.ts'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/examples/tanstack/src/routeTree.gen.ts
+++ b/examples/tanstack/src/routeTree.gen.ts
@@ -9,12 +9,38 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from "./routes/__root";
+import { Route as SitemapDotxmlRouteImport } from "./routes/sitemap[.]xml";
+import { Route as RobotsDottxtRouteImport } from "./routes/robots[.]txt";
+import { Route as OpenapiDotjsonRouteImport } from "./routes/openapi[.]json";
+import { Route as McpRouteImport } from "./routes/mcp";
 import { Route as DashboardRouteImport } from "./routes/dashboard";
 import { Route as BillingRouteImport } from "./routes/billing";
 import { Route as IndexRouteImport } from "./routes/index";
+import { Route as ApiHealthRouteImport } from "./routes/api/health";
+import { Route as DotwellKnownSplatRouteImport } from "./routes/[.]well-known/$";
 import { Route as BillingPaystackCallbackRouteImport } from "./routes/billing/paystack/callback";
 import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
 
+const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
+  id: "/sitemap.xml",
+  path: "/sitemap.xml",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
+  id: "/robots.txt",
+  path: "/robots.txt",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const OpenapiDotjsonRoute = OpenapiDotjsonRouteImport.update({
+  id: "/openapi.json",
+  path: "/openapi.json",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const McpRoute = McpRouteImport.update({
+  id: "/mcp",
+  path: "/mcp",
+  getParentRoute: () => rootRouteImport,
+} as any);
 const DashboardRoute = DashboardRouteImport.update({
   id: "/dashboard",
   path: "/dashboard",
@@ -28,6 +54,16 @@ const BillingRoute = BillingRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: "/",
   path: "/",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const ApiHealthRoute = ApiHealthRouteImport.update({
+  id: "/api/health",
+  path: "/api/health",
+  getParentRoute: () => rootRouteImport,
+} as any);
+const DotwellKnownSplatRoute = DotwellKnownSplatRouteImport.update({
+  id: "/.well-known/$",
+  path: "/.well-known/$",
   getParentRoute: () => rootRouteImport,
 } as any);
 const BillingPaystackCallbackRoute = BillingPaystackCallbackRouteImport.update({
@@ -45,6 +81,12 @@ export interface FileRoutesByFullPath {
   "/": typeof IndexRoute;
   "/billing": typeof BillingRouteWithChildren;
   "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
@@ -52,6 +94,12 @@ export interface FileRoutesByTo {
   "/": typeof IndexRoute;
   "/billing": typeof BillingRouteWithChildren;
   "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
@@ -60,26 +108,100 @@ export interface FileRoutesById {
   "/": typeof IndexRoute;
   "/billing": typeof BillingRouteWithChildren;
   "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
   "/api/auth/$": typeof ApiAuthSplatRoute;
   "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/billing" | "/dashboard" | "/api/auth/$" | "/billing/paystack/callback";
+  fullPaths:
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
   fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/billing" | "/dashboard" | "/api/auth/$" | "/billing/paystack/callback";
-  id: "__root__" | "/" | "/billing" | "/dashboard" | "/api/auth/$" | "/billing/paystack/callback";
+  to:
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
+  id:
+    | "__root__"
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
   fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute;
   BillingRoute: typeof BillingRouteWithChildren;
   DashboardRoute: typeof DashboardRoute;
+  McpRoute: typeof McpRoute;
+  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute;
+  RobotsDottxtRoute: typeof RobotsDottxtRoute;
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute;
+  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute;
+  ApiHealthRoute: typeof ApiHealthRoute;
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
 }
 
 declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
+    "/sitemap.xml": {
+      id: "/sitemap.xml";
+      path: "/sitemap.xml";
+      fullPath: "/sitemap.xml";
+      preLoaderRoute: typeof SitemapDotxmlRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/robots.txt": {
+      id: "/robots.txt";
+      path: "/robots.txt";
+      fullPath: "/robots.txt";
+      preLoaderRoute: typeof RobotsDottxtRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/openapi.json": {
+      id: "/openapi.json";
+      path: "/openapi.json";
+      fullPath: "/openapi.json";
+      preLoaderRoute: typeof OpenapiDotjsonRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/mcp": {
+      id: "/mcp";
+      path: "/mcp";
+      fullPath: "/mcp";
+      preLoaderRoute: typeof McpRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     "/dashboard": {
       id: "/dashboard";
       path: "/dashboard";
@@ -99,6 +221,20 @@ declare module "@tanstack/react-router" {
       path: "/";
       fullPath: "/";
       preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/api/health": {
+      id: "/api/health";
+      path: "/api/health";
+      fullPath: "/api/health";
+      preLoaderRoute: typeof ApiHealthRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/.well-known/$": {
+      id: "/.well-known/$";
+      path: "/.well-known/$";
+      fullPath: "/.well-known/$";
+      preLoaderRoute: typeof DotwellKnownSplatRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     "/billing/paystack/callback": {
@@ -132,6 +268,12 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   BillingRoute: BillingRouteWithChildren,
   DashboardRoute: DashboardRoute,
+  McpRoute: McpRoute,
+  OpenapiDotjsonRoute: OpenapiDotjsonRoute,
+  RobotsDottxtRoute: RobotsDottxtRoute,
+  SitemapDotxmlRoute: SitemapDotxmlRoute,
+  DotwellKnownSplatRoute: DotwellKnownSplatRoute,
+  ApiHealthRoute: ApiHealthRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
 };
 export const routeTree = rootRouteImport
@@ -139,10 +281,11 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>();
 
 import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
+import type { startInstance } from "./start.ts";
 declare module "@tanstack/react-start" {
   interface Register {
     ssr: true;
     router: Awaited<ReturnType<typeof getRouter>>;
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
   }
 }

--- a/examples/tanstack/src/routes/[.]well-known/$.ts
+++ b/examples/tanstack/src/routes/[.]well-known/$.ts
@@ -1,0 +1,59 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  getAgentSkillsIndex,
+  getApiCatalog,
+  getMcpServerCard,
+  getOAuthProtectedResource,
+  getOidcConfiguration,
+  getOrigin,
+  paystackSkillMarkdown,
+} from "@/lib/agent-discovery";
+
+export const Route = createFileRoute("/.well-known/$")({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => {
+        const origin = getOrigin(request);
+        const splat = params._splat;
+
+        if (splat === "api-catalog") {
+          return json(getApiCatalog(origin), "application/linkset+json");
+        }
+
+        if (splat === "openid-configuration" || splat === "oauth-authorization-server") {
+          return json(getOidcConfiguration(origin));
+        }
+
+        if (splat === "oauth-protected-resource") {
+          return json(getOAuthProtectedResource(origin));
+        }
+
+        if (splat === "mcp/server-card.json") {
+          return json(getMcpServerCard(origin));
+        }
+
+        if (splat === "agent-skills/index.json") {
+          return json(await getAgentSkillsIndex(origin));
+        }
+
+        if (splat === "agent-skills/better-auth-paystack-demo/SKILL.md") {
+          return new Response(paystackSkillMarkdown, {
+            headers: {
+              "Content-Type": "text/markdown; charset=utf-8",
+            },
+          });
+        }
+
+        return new Response("Not found", { status: 404 });
+      },
+    },
+  },
+});
+
+function json(value: unknown, contentType = "application/json") {
+  return Response.json(value, {
+    headers: {
+      "Content-Type": `${contentType}; charset=utf-8`,
+    },
+  });
+}

--- a/examples/tanstack/src/routes/api/health.ts
+++ b/examples/tanstack/src/routes/api/health.ts
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/api/health")({
+  server: {
+    handlers: {
+      GET: async () => {
+        return Response.json({
+          ok: true,
+          service: "better-auth-paystack-tanstack-example",
+        });
+      },
+    },
+  },
+});

--- a/examples/tanstack/src/routes/billing/paystack/callback.tsx
+++ b/examples/tanstack/src/routes/billing/paystack/callback.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, useRouter } from "@tanstack/react-router";
+import { useServerFn } from "@tanstack/react-start";
 import { useEffect, useRef, useState } from "react";
-import { authClient } from "@/lib/auth-client";
+import { verifyPaystackCallbackServerFn } from "@/lib/paystack-admin";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const Route = createFileRoute("/billing/paystack/callback")({
@@ -9,10 +10,9 @@ export const Route = createFileRoute("/billing/paystack/callback")({
 
 export function CallbackPage() {
   const router = useRouter();
-  const searchParams = Route.useSearch();
-  const reference =
-    ((searchParams as any).reference as string | undefined) ??
-    ((searchParams as any).trxref as string | undefined);
+  const verifyPaystackCallback = useServerFn(verifyPaystackCallbackServerFn);
+  const searchParams = Route.useSearch() as { reference?: string; trxref?: string };
+  const reference = searchParams.reference ?? searchParams.trxref;
   const [status, setStatus] = useState<"verifying" | "success" | "error">("verifying");
   const [error, setError] = useState("");
   const [successTitle, setSuccessTitle] = useState("Payment Successful!");
@@ -25,34 +25,9 @@ export function CallbackPage() {
 
     const verify = async () => {
       try {
-        let result:
-          | {
-              data?: { status?: string | null } | null;
-              error?: { message?: string | null } | null;
-            }
-          | undefined;
+        const result = await verifyPaystackCallback({ data: { reference } });
 
-        for (let attempt = 0; attempt < 4; attempt++) {
-          result = await (authClient as any).paystack.verifyTransaction({ reference });
-
-          const message = result?.error?.message ?? "";
-          const shouldRetry = message.includes("Transaction reference not found") && attempt < 3;
-
-          if (shouldRetry) {
-            await new Promise((resolve) => {
-              setTimeout(resolve, 750);
-            });
-            continue;
-          }
-
-          break;
-        }
-
-        if (result?.error !== null && result?.error !== undefined) {
-          throw new Error(result.error.message ?? "Verification failed");
-        }
-
-        if (result?.data?.status !== "success") {
+        if (result.data.status !== "success") {
           throw new Error("Verification did not complete successfully");
         }
 
@@ -124,7 +99,7 @@ export function CallbackPage() {
     };
 
     void verify();
-  }, [reference, router]);
+  }, [reference, router, verifyPaystackCallback]);
 
   if (reference === undefined || reference === "") {
     return (

--- a/examples/tanstack/src/routes/index.tsx
+++ b/examples/tanstack/src/routes/index.tsx
@@ -18,8 +18,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { linkHeader } from "@/lib/agent-discovery";
 
-export const Route = createFileRoute("/")({ component: Home });
+export const Route = createFileRoute("/")({
+  headers: () => ({
+    Link: linkHeader,
+  }),
+  component: Home,
+});
 
 function Home() {
   const router = useRouter();
@@ -31,6 +37,71 @@ function Home() {
       void router.navigate({ to: "/dashboard" });
     }
   }, [sessionData, router]);
+
+  useEffect(() => {
+    const modelContext = navigator.modelContext;
+
+    if (modelContext === undefined) {
+      return;
+    }
+
+    const controller = new AbortController();
+    const tools = [
+      {
+        name: "open_home",
+        description: "Navigate to the Better Auth Paystack demo home page.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: () => {
+          globalThis.location.assign("/");
+          return { ok: true };
+        },
+      },
+      {
+        name: "open_dashboard",
+        description: "Navigate to the authenticated billing dashboard.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: () => {
+          globalThis.location.assign("/dashboard");
+          return { ok: true };
+        },
+      },
+      {
+        name: "get_agent_resources",
+        description: "Return the site discovery resources for API and agent automation.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+        execute: () => ({
+          apiCatalog: "/.well-known/api-catalog",
+          openApi: "/openapi.json",
+          health: "/api/health",
+          sitemap: "/sitemap.xml",
+        }),
+      },
+    ];
+
+    if (modelContext.registerTool !== undefined) {
+      for (const tool of tools) {
+        modelContext.registerTool(tool, { signal: controller.signal });
+      }
+    } else if (modelContext.provideContext !== undefined) {
+      modelContext.provideContext({ tools }, { signal: controller.signal });
+    }
+
+    return () => {
+      controller.abort();
+    };
+  }, []);
 
   const handleAnonymousLogin = async () => {
     setIsAuthActionInProgress(true);

--- a/examples/tanstack/src/routes/mcp.ts
+++ b/examples/tanstack/src/routes/mcp.ts
@@ -1,0 +1,30 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/mcp")({
+  server: {
+    handlers: {
+      GET: async () => {
+        return Response.json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32_000,
+            message: "MCP transport is advertised for discovery only in this demo.",
+          },
+        });
+      },
+      POST: async () => {
+        return Response.json({
+          jsonrpc: "2.0",
+          result: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            serverInfo: {
+              name: "better-auth-paystack-tanstack-example",
+              version: "1.0.0",
+            },
+          },
+        });
+      },
+    },
+  },
+});

--- a/examples/tanstack/src/routes/openapi[.]json.ts
+++ b/examples/tanstack/src/routes/openapi[.]json.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getOpenApiDocument, getOrigin } from "@/lib/agent-discovery";
+
+export const Route = createFileRoute("/openapi.json")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return Response.json(getOpenApiDocument(getOrigin(request)), {
+          headers: {
+            "Content-Type": "application/vnd.oai.openapi+json; charset=utf-8",
+          },
+        });
+      },
+    },
+  },
+});

--- a/examples/tanstack/src/routes/robots[.]txt.ts
+++ b/examples/tanstack/src/routes/robots[.]txt.ts
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { absoluteUrl, getOrigin } from "@/lib/agent-discovery";
+
+export const Route = createFileRoute("/robots.txt")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const origin = getOrigin(request);
+
+        return new Response(
+          `User-agent: *
+Disallow:
+Content-Signal: ai-train=no, search=yes, ai-input=yes
+
+Sitemap: ${absoluteUrl(origin, "/sitemap.xml")}
+`,
+          {
+            headers: {
+              "Content-Type": "text/plain; charset=utf-8",
+            },
+          },
+        );
+      },
+    },
+  },
+});

--- a/examples/tanstack/src/routes/sitemap[.]xml.ts
+++ b/examples/tanstack/src/routes/sitemap[.]xml.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getOrigin, getSitemapXml } from "@/lib/agent-discovery";
+
+export const Route = createFileRoute("/sitemap.xml")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        return new Response(getSitemapXml(getOrigin(request)), {
+          headers: {
+            "Content-Type": "application/xml; charset=utf-8",
+          },
+        });
+      },
+    },
+  },
+});

--- a/examples/tanstack/src/start.ts
+++ b/examples/tanstack/src/start.ts
@@ -1,0 +1,30 @@
+import { createMiddleware, createStart } from "@tanstack/react-start";
+import { homeMarkdown, linkHeader, markdownTokenCount } from "@/lib/agent-discovery";
+
+const agentDiscoveryMiddleware = createMiddleware().server(async ({ next, request }) => {
+  const url = new URL(request.url);
+  const acceptsMarkdown = request.headers.get("accept")?.includes("text/markdown") === true;
+
+  if (request.method === "GET" && url.pathname === "/" && acceptsMarkdown) {
+    return new Response(homeMarkdown, {
+      headers: {
+        "Content-Type": "text/markdown; charset=utf-8",
+        Link: linkHeader,
+        "x-markdown-tokens": markdownTokenCount(homeMarkdown),
+      },
+    });
+  }
+
+  const result = await next();
+  const response = result.response;
+
+  if (request.method === "GET" && url.pathname === "/" && response !== undefined) {
+    response.headers.set("Link", linkHeader);
+  }
+
+  return result;
+});
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [agentDiscoveryMiddleware],
+}));

--- a/examples/tanstack/src/vite-env.d.ts
+++ b/examples/tanstack/src/vite-env.d.ts
@@ -4,3 +4,17 @@ declare module "*.css?url" {
   const content: string;
   export default content;
 }
+
+interface WebMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input?: unknown) => unknown | Promise<unknown>;
+}
+
+interface Navigator {
+  modelContext?: {
+    registerTool?: (tool: WebMcpTool, options?: { signal?: AbortSignal }) => void;
+    provideContext?: (context: { tools: WebMcpTool[] }, options?: { signal?: AbortSignal }) => void;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@alexasomba/paystack-node':
-      specifier: ^1.9.4
-      version: 1.9.4
+      specifier: ^1.10.1
+      version: 1.10.1
     '@arethetypeswrong/cli':
       specifier: ^0.18.2
       version: 0.18.2
@@ -209,7 +209,7 @@ importers:
     dependencies:
       '@alexasomba/paystack-node':
         specifier: 'catalog:'
-        version: 1.9.4
+        version: 1.10.1
       better-call:
         specifier: 'catalog:'
         version: 1.3.5(zod@4.4.3)
@@ -295,7 +295,7 @@ importers:
         version: link:../..
       '@alexasomba/paystack-node':
         specifier: 'catalog:'
-        version: 1.9.4
+        version: 1.10.1
       '@base-ui/react':
         specifier: 'catalog:'
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -447,8 +447,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@alexasomba/paystack-node@1.9.4':
-    resolution: {integrity: sha512-1N5gMdz9JgqDsrTK891Owk2XEaTeG6zMtGpKbTZaVj71+/d/4rGSRykETcT/8gAAf3ikXkVBUvC57OYGjRdS0A==}
+  '@alexasomba/paystack-node@1.10.1':
+    resolution: {integrity: sha512-w8rj+k5sag8oeR5BvbsGwuWQ9KDXBZFzlxEtSClgIJcoVvWAbcp1sBI4cL+k5+D8Wd2KjEbJBgUlbZUxRVMNxw==}
     engines: {node: '>=22.0.0'}
 
   '@andrewbranch/untar.js@1.0.3':
@@ -4734,7 +4734,7 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@alexasomba/paystack-node@1.9.4':
+  '@alexasomba/paystack-node@1.10.1':
     dependencies:
       openapi-fetch: 0.17.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       tw-animate-css:
         specifier: 'catalog:'
         version: 1.4.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - "examples/*"
 
 catalog:
-  "@alexasomba/paystack-node": "^1.9.4"
+  "@alexasomba/paystack-node": "^1.10.1"
   "@arethetypeswrong/cli": "^0.18.2"
   "@base-ui/react": "^1.4.1"
   "@better-auth/core": "^1.6.9"

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -12,7 +12,7 @@ import type {
   PaystackPlan,
   PaystackProduct,
   PaystackSyncResult,
-  PaystackTransactionResponse,
+  PaystackChargeAuthorizationResponse,
   Subscription,
   User,
 } from "./types";
@@ -239,7 +239,7 @@ export async function chargeSubscriptionRenewal(
     },
   });
 
-  const chargeData = unwrapSdkResult<PaystackTransactionResponse>(chargeResRaw);
+  const chargeData = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
   if (chargeData?.status === "success" && chargeData.reference !== undefined) {
     const now = new Date();
     const nextPeriodEnd = getNextPeriodEnd(now, plan.interval ?? "monthly");

--- a/src/paystack-sdk.ts
+++ b/src/paystack-sdk.ts
@@ -1,5 +1,5 @@
 import { APIError } from "better-auth/api";
-import { PaystackResponse } from "@alexasomba/paystack-node";
+import { PaystackError, PaystackResponse } from "@alexasomba/paystack-node";
 import type { PaystackClientLike } from "./types";
 
 /**
@@ -18,6 +18,13 @@ export function unwrapSdkResult<T = unknown>(result: unknown): T {
     try {
       return result.unwrap() as T;
     } catch (e: unknown) {
+      if (e instanceof PaystackError) {
+        throw new APIError("BAD_REQUEST", {
+          message: e.message,
+          status: e.status,
+        });
+      }
+
       throw new APIError("BAD_REQUEST", {
         message: (e as Error)?.message ?? "Paystack API error",
       });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,6 +23,8 @@ import type {
   PaystackPlan,
   PaystackWebhookPayload,
   PaystackTransactionResponse,
+  PaystackChargeAuthorizationResponse,
+  ChargeRecurringSubscriptionResult,
   Session,
   User,
   PaystackUser,
@@ -1035,7 +1037,7 @@ export const initializeTransaction = <P extends string = "/initialize-transactio
                       metadata: JSON.stringify(prorationMetadata),
                     },
                   });
-                  const sdkRes = unwrapSdkResult<PaystackTransactionResponse>(chargeResRaw);
+                  const sdkRes = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
 
                   if (sdkRes?.status !== "success") {
                     throw new APIError("BAD_REQUEST", {
@@ -2785,90 +2787,7 @@ export const chargeRecurringSubscription = <P extends string = "/charge-recurrin
       z.core.$strip
     >;
   },
-  {
-    status: string;
-    data: {
-      id: number;
-      domain: string;
-      status: string;
-      reference: string;
-      receipt_number: string | null;
-      amount: number;
-      message: string | null;
-      gateway_response: string;
-      channel: string;
-      currency: string;
-      ip_address: string | null;
-      metadata: (string | Record<string, never> | number) | null;
-      log: {
-        start_time: number;
-        time_spent: number;
-        attempts: number;
-        errors: number;
-        success: boolean;
-        mobile: boolean;
-        input: unknown[];
-        history: {
-          type: string;
-          message: string;
-          time: number;
-        }[];
-      } | null;
-      fees: number | null;
-      fees_split: unknown;
-      authorization: {
-        authorization_code?: string;
-        bin?: string | null;
-        last4?: string;
-        exp_month?: string;
-        exp_year?: string;
-        channel?: string;
-        card_type?: string;
-        bank?: string;
-        country_code?: string;
-        brand?: string;
-        reusable?: boolean;
-        signature?: string;
-        account_name?: string | null;
-        receiver_bank_account_number?: string | null;
-        receiver_bank?: string | null;
-      };
-      customer: {
-        id: number;
-        first_name: string | null;
-        last_name: string | null;
-        email: string;
-        customer_code: string;
-        phone: string | null;
-        metadata: Record<string, never> | null;
-        risk_action: string;
-        international_format_phone?: string | null;
-      };
-      plan: (string | Record<string, never>) | null;
-      split: Record<string, never> | null;
-      order_id: unknown;
-      paidAt: string | null;
-      createdAt: string;
-      requested_amount: number;
-      pos_transaction_data: unknown;
-      source: unknown;
-      fees_breakdown: unknown;
-      connect: unknown;
-      transaction_date: string;
-      plan_object: {
-        id?: number;
-        name?: string;
-        plan_code?: string;
-        description?: unknown;
-        amount?: number;
-        interval?: string;
-        send_invoices?: boolean;
-        send_sms?: boolean;
-        currency?: string;
-      };
-      subaccount: Record<string, never> | null;
-    };
-  }
+  ChargeRecurringSubscriptionResult
 > => {
   return createAuthEndpoint(
     path,
@@ -2965,7 +2884,7 @@ export const chargeRecurringSubscription = <P extends string = "/charge-recurrin
         },
       });
 
-      const chargeData = unwrapSdkResult<PaystackTransactionResponse>(chargeResRaw);
+      const chargeData = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
 
       if (chargeData?.status === "success" && chargeData.reference !== undefined) {
         const now = new Date();

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,12 @@ import type {
   PaystackProductClient,
   PaystackSubscriptionClient,
   PaystackTransactionClient,
+  TransactionChargeAuthorizationResponseData,
+  TransactionVerifyResponseData,
+  PlanListResponseData,
+  CustomerCreateResponseData,
+  SubscriptionListResponseData,
+  ProductFetchResponseData,
   components,
 } from "@alexasomba/paystack-node";
 import type { PaystackPluginSchema } from "./schema";
@@ -131,12 +137,12 @@ export type PaystackWebhookPayload = PaystackWebhookEvent;
 /**
  * Paystack SDK Result types
  */
-export type PaystackTransactionResponse = components["schemas"]["VerifyResponse"]["data"];
-export type PaystackPlanResponse = components["schemas"]["PlanListResponseArray"];
-export type PaystackCustomerResponse =
-  components["schemas"]["ChargeAuthorizationResponse"]["data"]["customer"];
-export type PaystackSubscriptionResponse = components["schemas"]["SubscriptionListResponseArray"];
-export type PaystackProductResponse = components["schemas"]["ProductListsResponseArray"];
+export type PaystackTransactionResponse = TransactionVerifyResponseData;
+export type PaystackChargeAuthorizationResponse = TransactionChargeAuthorizationResponseData;
+export type PaystackPlanResponse = PlanListResponseData;
+export type PaystackCustomerResponse = CustomerCreateResponseData;
+export type PaystackSubscriptionResponse = SubscriptionListResponseData;
+export type PaystackProductResponse = ProductFetchResponseData;
 
 export interface SubscriptionOptions {
   /**
@@ -299,7 +305,7 @@ export interface ChargeRecurringSubscriptionInput {
 
 export interface ChargeRecurringSubscriptionResult {
   status: "success" | "failed";
-  data: PaystackTransactionResponse;
+  data: PaystackChargeAuthorizationResponse;
 }
 
 export interface PaystackSyncResult {


### PR DESCRIPTION
## Summary
- update Paystack SDK integration work
- harden TanStack example tests and error handling
- add agent discovery metadata, sitemap, robots content signals, markdown negotiation, Link headers, API catalog, OAuth discovery, MCP server card, and WebMCP tools

## Verification
- vp run --filter tanstack-start-better-auth-paystack build
- vp test
- vp check --no-fmt

Note: full vp check currently reports formatting on generated examples/tanstack/src/routeTree.gen.ts even after vp check --fix leaves no diff.