### PR TITLE
refactor: deepen Paystack billing architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npmjs
-        run: pnpm publish --access public --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
+        run: pnpm publish --access public --provenance --no-git-checks --tag ${{ steps.determine_npm_tag.outputs.npm_tag }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,9 @@
 
 ## [2.4.2](https://github.com/alexasomba/better-auth-paystack/compare/v2.4.1...v2.4.2) (2026-05-09)
 
-
 ### Miscellaneous Chores
 
-* update paystack node sdk ([#125](https://github.com/alexasomba/better-auth-paystack/issues/125)) ([5ae336d](https://github.com/alexasomba/better-auth-paystack/commit/5ae336d7d5a153c072c34be35a359c46c9a5dd0c))
+- update paystack node sdk ([#125](https://github.com/alexasomba/better-auth-paystack/issues/125)) ([5ae336d](https://github.com/alexasomba/better-auth-paystack/commit/5ae336d7d5a153c072c34be35a359c46c9a5dd0c))
 
 ## [2.4.0](https://github.com/alexasomba/better-auth-paystack/compare/better-auth-paystack-v2.3.0...better-auth-paystack-v2.4.0) (2026-05-09)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,27 @@
+# Context
+
+## Domain Terms
+
+### Billing Reference
+
+A user or organization identifier used as the owner of Paystack transactions, subscriptions, limits, and billing history. A billing reference can be the session user id or an organization id authorized for billing actions.
+
+### Reference Access
+
+The authorization decision for a billing reference and billing action. Reference access is granted to the billing reference owner, to organization owner/admin members, or by `subscription.authorizeReference`.
+
+### Billing Store
+
+The persistence module for Paystack billing records stored through the Better Auth adapter. It owns subscription lookup, transaction recording, catalog persistence, customer-code writes, and current subscription selection.
+
+### Paystack Adapter
+
+The module that hides Paystack SDK response shapes and grouped SDK operations behind normalized billing operations.
+
+### Subscription Lifecycle
+
+The workflow that turns checkout, verification, trials, proration, renewals, and scheduled changes into local subscription and transaction state.
+
+### Trusted Operation
+
+A server-only billing operation that must not be exposed as a browser-triggered auth endpoint. Catalog sync and local subscription renewal are trusted operations.

--- a/_artifacts/domain_map.yaml
+++ b/_artifacts/domain_map.yaml
@@ -1,5 +1,5 @@
 library:
-  name: '@alexasomba/better-auth-paystack'
+  name: "@alexasomba/better-auth-paystack"
   version: 2.4.2
   repository: https://github.com/alexasomba/better-auth-paystack
   description: >-

--- a/_artifacts/skill_spec.md
+++ b/_artifacts/skill_spec.md
@@ -33,6 +33,8 @@ Generate flat skills because the package is focused and has fewer than five high
 
 ## Shared Constraints
 
+- Include `license: "MIT"` and `compatibility` frontmatter in every skill shipped to npm.
+- Compatibility must state Node.js `>=24.0.0`, Better Auth `^1.6.9`, `@alexasomba/paystack-node` `1.10.x`, and the supported `@alexasomba/better-auth-paystack` line `>=2.4.2 <3.0.0`.
 - Do not instruct agents to import from `@better-auth/core/*` in runtime package code.
 - Keep product and plan schema tables enabled by default.
 - Prefer canonical client methods over deprecated `subscription.disable` and `subscription.enable` aliases.

--- a/_artifacts/skill_tree.yaml
+++ b/_artifacts/skill_tree.yaml
@@ -1,5 +1,5 @@
 library:
-  name: '@alexasomba/better-auth-paystack'
+  name: "@alexasomba/better-auth-paystack"
   version: 2.4.2
   repository: https://github.com/alexasomba/better-auth-paystack
   description: >-
@@ -8,7 +8,7 @@ library:
 generated_from:
   domain_map: _artifacts/domain_map.yaml
   skill_spec: _artifacts/skill_spec.md
-generated_at: '2026-05-09T00:00:00Z'
+generated_at: "2026-05-09T00:00:00Z"
 skills:
   - name: better-auth-paystack/setup
     slug: setup

--- a/_artifacts/skill_tree.yaml
+++ b/_artifacts/skill_tree.yaml
@@ -2,6 +2,8 @@ library:
   name: "@alexasomba/better-auth-paystack"
   version: 2.4.2
   repository: https://github.com/alexasomba/better-auth-paystack
+  license: MIT
+  compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
   description: >-
     Paystack billing plugin for Better Auth with subscriptions, transactions,
     organization billing, and webhooks.
@@ -15,6 +17,8 @@ skills:
     type: core
     domain: setup
     path: skills/setup/SKILL.md
+    license: MIT
+    compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
     description: >-
       Configure the Better Auth Paystack server and client plugins, schema,
       products, plans, webhook secret, and canonical client actions.
@@ -28,6 +32,8 @@ skills:
     type: core
     domain: subscriptions-and-transactions
     path: skills/subscriptions-and-transactions/SKILL.md
+    license: MIT
+    compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
     description: >-
       Build Paystack checkout, transaction verification, subscription lifecycle,
       products/plans, and server-only renewal/sync flows.
@@ -41,6 +47,8 @@ skills:
     type: core
     domain: organization-billing
     path: skills/organization-billing/SKILL.md
+    license: MIT
+    compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
     description: >-
       Configure organization billing authorization, owner/admin defaults, custom
       authorizeReference, organization customer creation, and seat/team limits.
@@ -54,6 +62,8 @@ skills:
     type: core
     domain: billing-catalog-and-limits
     path: skills/billing-catalog-and-limits/SKILL.md
+    license: MIT
+    compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
     description: >-
       Configure products, Paystack-native plans, local plans, free trials, seat
       billing, plan limits, and catalog sync jobs.
@@ -68,6 +78,8 @@ skills:
     type: composition
     domain: tanstack-start
     path: skills/tanstack-start/SKILL.md
+    license: MIT
+    compatibility: Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0
     description: >-
       Integrate Better Auth Paystack in TanStack Start with auth routes,
       tanstackStartCookies, server functions, client actions, and Cloudflare

--- a/examples/tanstack/src/routeTree.gen.ts
+++ b/examples/tanstack/src/routeTree.gen.ts
@@ -8,262 +8,261 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
-import { Route as RobotsDottxtRouteImport } from './routes/robots[.]txt'
-import { Route as OpenapiDotjsonRouteImport } from './routes/openapi[.]json'
-import { Route as McpRouteImport } from './routes/mcp'
-import { Route as DashboardRouteImport } from './routes/dashboard'
-import { Route as BillingRouteImport } from './routes/billing'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as ApiHealthRouteImport } from './routes/api/health'
-import { Route as DotwellKnownSplatRouteImport } from './routes/[.]well-known/$'
-import { Route as BillingPaystackCallbackRouteImport } from './routes/billing/paystack/callback'
-import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as SitemapDotxmlRouteImport } from "./routes/sitemap[.]xml";
+import { Route as RobotsDottxtRouteImport } from "./routes/robots[.]txt";
+import { Route as OpenapiDotjsonRouteImport } from "./routes/openapi[.]json";
+import { Route as McpRouteImport } from "./routes/mcp";
+import { Route as DashboardRouteImport } from "./routes/dashboard";
+import { Route as BillingRouteImport } from "./routes/billing";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as ApiHealthRouteImport } from "./routes/api/health";
+import { Route as DotwellKnownSplatRouteImport } from "./routes/[.]well-known/$";
+import { Route as BillingPaystackCallbackRouteImport } from "./routes/billing/paystack/callback";
+import { Route as ApiAuthSplatRouteImport } from "./routes/api/auth/$";
 
 const SitemapDotxmlRoute = SitemapDotxmlRouteImport.update({
-  id: '/sitemap.xml',
-  path: '/sitemap.xml',
+  id: "/sitemap.xml",
+  path: "/sitemap.xml",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const RobotsDottxtRoute = RobotsDottxtRouteImport.update({
-  id: '/robots.txt',
-  path: '/robots.txt',
+  id: "/robots.txt",
+  path: "/robots.txt",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const OpenapiDotjsonRoute = OpenapiDotjsonRouteImport.update({
-  id: '/openapi.json',
-  path: '/openapi.json',
+  id: "/openapi.json",
+  path: "/openapi.json",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const McpRoute = McpRouteImport.update({
-  id: '/mcp',
-  path: '/mcp',
+  id: "/mcp",
+  path: "/mcp",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DashboardRoute = DashboardRouteImport.update({
-  id: '/dashboard',
-  path: '/dashboard',
+  id: "/dashboard",
+  path: "/dashboard",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const BillingRoute = BillingRouteImport.update({
-  id: '/billing',
-  path: '/billing',
+  id: "/billing",
+  path: "/billing",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiHealthRoute = ApiHealthRouteImport.update({
-  id: '/api/health',
-  path: '/api/health',
+  id: "/api/health",
+  path: "/api/health",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DotwellKnownSplatRoute = DotwellKnownSplatRouteImport.update({
-  id: '/.well-known/$',
-  path: '/.well-known/$',
+  id: "/.well-known/$",
+  path: "/.well-known/$",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const BillingPaystackCallbackRoute = BillingPaystackCallbackRouteImport.update({
-  id: '/paystack/callback',
-  path: '/paystack/callback',
+  id: "/paystack/callback",
+  path: "/paystack/callback",
   getParentRoute: () => BillingRoute,
-} as any)
+} as any);
 const ApiAuthSplatRoute = ApiAuthSplatRouteImport.update({
-  id: '/api/auth/$',
-  path: '/api/auth/$',
+  id: "/api/auth/$",
+  path: "/api/auth/$",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRouteWithChildren
-  '/dashboard': typeof DashboardRoute
-  '/mcp': typeof McpRoute
-  '/openapi.json': typeof OpenapiDotjsonRoute
-  '/robots.txt': typeof RobotsDottxtRoute
-  '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/.well-known/$': typeof DotwellKnownSplatRoute
-  '/api/health': typeof ApiHealthRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRouteWithChildren;
+  "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRouteWithChildren
-  '/dashboard': typeof DashboardRoute
-  '/mcp': typeof McpRoute
-  '/openapi.json': typeof OpenapiDotjsonRoute
-  '/robots.txt': typeof RobotsDottxtRoute
-  '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/.well-known/$': typeof DotwellKnownSplatRoute
-  '/api/health': typeof ApiHealthRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRouteWithChildren;
+  "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/billing': typeof BillingRouteWithChildren
-  '/dashboard': typeof DashboardRoute
-  '/mcp': typeof McpRoute
-  '/openapi.json': typeof OpenapiDotjsonRoute
-  '/robots.txt': typeof RobotsDottxtRoute
-  '/sitemap.xml': typeof SitemapDotxmlRoute
-  '/.well-known/$': typeof DotwellKnownSplatRoute
-  '/api/health': typeof ApiHealthRoute
-  '/api/auth/$': typeof ApiAuthSplatRoute
-  '/billing/paystack/callback': typeof BillingPaystackCallbackRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/billing": typeof BillingRouteWithChildren;
+  "/dashboard": typeof DashboardRoute;
+  "/mcp": typeof McpRoute;
+  "/openapi.json": typeof OpenapiDotjsonRoute;
+  "/robots.txt": typeof RobotsDottxtRoute;
+  "/sitemap.xml": typeof SitemapDotxmlRoute;
+  "/.well-known/$": typeof DotwellKnownSplatRoute;
+  "/api/health": typeof ApiHealthRoute;
+  "/api/auth/$": typeof ApiAuthSplatRoute;
+  "/billing/paystack/callback": typeof BillingPaystackCallbackRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
+  fileRoutesByFullPath: FileRoutesByFullPath;
   fullPaths:
-    | '/'
-    | '/billing'
-    | '/dashboard'
-    | '/mcp'
-    | '/openapi.json'
-    | '/robots.txt'
-    | '/sitemap.xml'
-    | '/.well-known/$'
-    | '/api/health'
-    | '/api/auth/$'
-    | '/billing/paystack/callback'
-  fileRoutesByTo: FileRoutesByTo
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
+  fileRoutesByTo: FileRoutesByTo;
   to:
-    | '/'
-    | '/billing'
-    | '/dashboard'
-    | '/mcp'
-    | '/openapi.json'
-    | '/robots.txt'
-    | '/sitemap.xml'
-    | '/.well-known/$'
-    | '/api/health'
-    | '/api/auth/$'
-    | '/billing/paystack/callback'
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
   id:
-    | '__root__'
-    | '/'
-    | '/billing'
-    | '/dashboard'
-    | '/mcp'
-    | '/openapi.json'
-    | '/robots.txt'
-    | '/sitemap.xml'
-    | '/.well-known/$'
-    | '/api/health'
-    | '/api/auth/$'
-    | '/billing/paystack/callback'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/billing"
+    | "/dashboard"
+    | "/mcp"
+    | "/openapi.json"
+    | "/robots.txt"
+    | "/sitemap.xml"
+    | "/.well-known/$"
+    | "/api/health"
+    | "/api/auth/$"
+    | "/billing/paystack/callback";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  BillingRoute: typeof BillingRouteWithChildren
-  DashboardRoute: typeof DashboardRoute
-  McpRoute: typeof McpRoute
-  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute
-  RobotsDottxtRoute: typeof RobotsDottxtRoute
-  SitemapDotxmlRoute: typeof SitemapDotxmlRoute
-  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute
-  ApiHealthRoute: typeof ApiHealthRoute
-  ApiAuthSplatRoute: typeof ApiAuthSplatRoute
+  IndexRoute: typeof IndexRoute;
+  BillingRoute: typeof BillingRouteWithChildren;
+  DashboardRoute: typeof DashboardRoute;
+  McpRoute: typeof McpRoute;
+  OpenapiDotjsonRoute: typeof OpenapiDotjsonRoute;
+  RobotsDottxtRoute: typeof RobotsDottxtRoute;
+  SitemapDotxmlRoute: typeof SitemapDotxmlRoute;
+  DotwellKnownSplatRoute: typeof DotwellKnownSplatRoute;
+  ApiHealthRoute: typeof ApiHealthRoute;
+  ApiAuthSplatRoute: typeof ApiAuthSplatRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/sitemap.xml': {
-      id: '/sitemap.xml'
-      path: '/sitemap.xml'
-      fullPath: '/sitemap.xml'
-      preLoaderRoute: typeof SitemapDotxmlRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/robots.txt': {
-      id: '/robots.txt'
-      path: '/robots.txt'
-      fullPath: '/robots.txt'
-      preLoaderRoute: typeof RobotsDottxtRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/openapi.json': {
-      id: '/openapi.json'
-      path: '/openapi.json'
-      fullPath: '/openapi.json'
-      preLoaderRoute: typeof OpenapiDotjsonRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/mcp': {
-      id: '/mcp'
-      path: '/mcp'
-      fullPath: '/mcp'
-      preLoaderRoute: typeof McpRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/dashboard': {
-      id: '/dashboard'
-      path: '/dashboard'
-      fullPath: '/dashboard'
-      preLoaderRoute: typeof DashboardRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/billing': {
-      id: '/billing'
-      path: '/billing'
-      fullPath: '/billing'
-      preLoaderRoute: typeof BillingRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/health': {
-      id: '/api/health'
-      path: '/api/health'
-      fullPath: '/api/health'
-      preLoaderRoute: typeof ApiHealthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/.well-known/$': {
-      id: '/.well-known/$'
-      path: '/.well-known/$'
-      fullPath: '/.well-known/$'
-      preLoaderRoute: typeof DotwellKnownSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/billing/paystack/callback': {
-      id: '/billing/paystack/callback'
-      path: '/paystack/callback'
-      fullPath: '/billing/paystack/callback'
-      preLoaderRoute: typeof BillingPaystackCallbackRouteImport
-      parentRoute: typeof BillingRoute
-    }
-    '/api/auth/$': {
-      id: '/api/auth/$'
-      path: '/api/auth/$'
-      fullPath: '/api/auth/$'
-      preLoaderRoute: typeof ApiAuthSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/sitemap.xml": {
+      id: "/sitemap.xml";
+      path: "/sitemap.xml";
+      fullPath: "/sitemap.xml";
+      preLoaderRoute: typeof SitemapDotxmlRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/robots.txt": {
+      id: "/robots.txt";
+      path: "/robots.txt";
+      fullPath: "/robots.txt";
+      preLoaderRoute: typeof RobotsDottxtRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/openapi.json": {
+      id: "/openapi.json";
+      path: "/openapi.json";
+      fullPath: "/openapi.json";
+      preLoaderRoute: typeof OpenapiDotjsonRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/mcp": {
+      id: "/mcp";
+      path: "/mcp";
+      fullPath: "/mcp";
+      preLoaderRoute: typeof McpRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/dashboard": {
+      id: "/dashboard";
+      path: "/dashboard";
+      fullPath: "/dashboard";
+      preLoaderRoute: typeof DashboardRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/billing": {
+      id: "/billing";
+      path: "/billing";
+      fullPath: "/billing";
+      preLoaderRoute: typeof BillingRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/api/health": {
+      id: "/api/health";
+      path: "/api/health";
+      fullPath: "/api/health";
+      preLoaderRoute: typeof ApiHealthRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/.well-known/$": {
+      id: "/.well-known/$";
+      path: "/.well-known/$";
+      fullPath: "/.well-known/$";
+      preLoaderRoute: typeof DotwellKnownSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/billing/paystack/callback": {
+      id: "/billing/paystack/callback";
+      path: "/paystack/callback";
+      fullPath: "/billing/paystack/callback";
+      preLoaderRoute: typeof BillingPaystackCallbackRouteImport;
+      parentRoute: typeof BillingRoute;
+    };
+    "/api/auth/$": {
+      id: "/api/auth/$";
+      path: "/api/auth/$";
+      fullPath: "/api/auth/$";
+      preLoaderRoute: typeof ApiAuthSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
 interface BillingRouteChildren {
-  BillingPaystackCallbackRoute: typeof BillingPaystackCallbackRoute
+  BillingPaystackCallbackRoute: typeof BillingPaystackCallbackRoute;
 }
 
 const BillingRouteChildren: BillingRouteChildren = {
   BillingPaystackCallbackRoute: BillingPaystackCallbackRoute,
-}
+};
 
-const BillingRouteWithChildren =
-  BillingRoute._addFileChildren(BillingRouteChildren)
+const BillingRouteWithChildren = BillingRoute._addFileChildren(BillingRouteChildren);
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -276,17 +275,17 @@ const rootRouteChildren: RootRouteChildren = {
   DotwellKnownSplatRoute: DotwellKnownSplatRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { startInstance } from './start.ts'
-declare module '@tanstack/react-start' {
+import type { getRouter } from "./router.tsx";
+import type { startInstance } from "./start.ts";
+declare module "@tanstack/react-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-    config: Awaited<ReturnType<typeof startInstance.getOptions>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
+    config: Awaited<ReturnType<typeof startInstance.getOptions>>;
   }
 }

--- a/skills/billing-catalog-and-limits/SKILL.md
+++ b/skills/billing-catalog-and-limits/SKILL.md
@@ -5,6 +5,8 @@ description: >
 type: core
 library: "@alexasomba/better-auth-paystack"
 library_version: "2.4.2" # x-release-please-version
+license: "MIT"
+compatibility: "Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0"
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/types.ts"

--- a/skills/organization-billing/SKILL.md
+++ b/skills/organization-billing/SKILL.md
@@ -5,6 +5,8 @@ description: >
 type: core
 library: "@alexasomba/better-auth-paystack"
 library_version: "2.4.2" # x-release-please-version
+license: "MIT"
+compatibility: "Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0"
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/index.ts"

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,6 +5,8 @@ description: >
 type: core
 library: "@alexasomba/better-auth-paystack"
 library_version: "2.4.2" # x-release-please-version
+license: "MIT"
+compatibility: "Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0"
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/index.ts"

--- a/skills/subscriptions-and-transactions/SKILL.md
+++ b/skills/subscriptions-and-transactions/SKILL.md
@@ -5,6 +5,8 @@ description: >
 type: core
 library: "@alexasomba/better-auth-paystack"
 library_version: "2.4.2" # x-release-please-version
+license: "MIT"
+compatibility: "Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0"
 sources:
   - "alexasomba/better-auth-paystack:README.md"
   - "alexasomba/better-auth-paystack:src/routes.ts"

--- a/skills/tanstack-start/SKILL.md
+++ b/skills/tanstack-start/SKILL.md
@@ -5,6 +5,8 @@ description: >
 type: composition
 library: "@alexasomba/better-auth-paystack"
 library_version: "2.4.2" # x-release-please-version
+license: "MIT"
+compatibility: "Node.js >=24.0.0; better-auth ^1.6.9; @alexasomba/paystack-node 1.10.x; @alexasomba/better-auth-paystack >=2.4.2 <3.0.0"
 sources:
   - "alexasomba/better-auth-paystack:examples/tanstack/README.md"
   - "alexasomba/better-auth-paystack:examples/tanstack/src/lib/auth.ts"

--- a/src/billing-store.ts
+++ b/src/billing-store.ts
@@ -1,0 +1,224 @@
+import type { GenericEndpointContext } from "better-auth";
+
+import type {
+  Member,
+  PaystackOrganization,
+  PaystackPlan,
+  PaystackProduct,
+  PaystackTransaction,
+  Subscription,
+  User,
+} from "./types";
+
+type Adapter = GenericEndpointContext["context"]["adapter"];
+type WhereValue = string | number | boolean | null;
+type WhereClause = { field: string; value: WhereValue }[];
+
+export interface BillingStore {
+  findSubscriptionById(id: string): Promise<Subscription | null>;
+  findSubscriptionByCode(subscriptionCode: string): Promise<Subscription | null>;
+  findSubscriptionsByReference(referenceId: string): Promise<Subscription[]>;
+  findCurrentSubscription(referenceId: string): Promise<Subscription | null>;
+  findSubscriptionsByTransactionReference(reference: string): Promise<Subscription[]>;
+  createSubscription(data: Partial<Subscription> & Record<string, unknown>): Promise<Subscription>;
+  updateSubscription(
+    id: string,
+    update: Partial<Subscription> & Record<string, unknown>,
+  ): Promise<Subscription | null>;
+  updateSubscriptionByCode(
+    subscriptionCode: string,
+    update: Partial<Subscription> & Record<string, unknown>,
+  ): Promise<Subscription | null>;
+  createTransaction(
+    data: Partial<PaystackTransaction> & Record<string, unknown>,
+  ): Promise<PaystackTransaction>;
+  findTransactionByReference(reference: string): Promise<PaystackTransaction | null>;
+  updateTransactionByReference(
+    reference: string,
+    update: Partial<PaystackTransaction> & Record<string, unknown>,
+  ): Promise<PaystackTransaction | null>;
+  listTransactions(referenceId: string): Promise<PaystackTransaction[]>;
+  listProducts(): Promise<PaystackProduct[]>;
+  findProductByName(name: string): Promise<PaystackProduct | null>;
+  findProductBySlug(slug: string): Promise<PaystackProduct | null>;
+  updateProduct(
+    id: string,
+    update: Partial<PaystackProduct> & Record<string, unknown>,
+  ): Promise<void>;
+  upsertProductByPaystackId(
+    paystackId: string,
+    data: Partial<PaystackProduct> & Record<string, unknown>,
+  ): Promise<void>;
+  listPlans(): Promise<PaystackPlan[]>;
+  findPlanByName(name: string): Promise<PaystackPlan | null>;
+  findPlanByCode(planCode: string): Promise<PaystackPlan | null>;
+  upsertPlanByPaystackId(
+    paystackId: string,
+    data: Partial<PaystackPlan> & Record<string, unknown>,
+  ): Promise<void>;
+  findUser(id: string): Promise<User | null>;
+  findOrganization(id: string): Promise<PaystackOrganization | null>;
+  findOrganizationOwner(organizationId: string): Promise<Member | null>;
+  listMembers(organizationId: string): Promise<Member[]>;
+  listTeams(organizationId: string): Promise<unknown[]>;
+  saveCustomerCode(
+    referenceId: string,
+    customerCode: string,
+    isOrganization: boolean,
+  ): Promise<void>;
+}
+
+function sortSubscriptionsForCurrent(subscriptions: Subscription[]): Subscription[] {
+  const statusRank = new Map([
+    ["active", 0],
+    ["trialing", 1],
+    ["incomplete", 2],
+    ["past_due", 3],
+    ["canceled", 4],
+  ]);
+
+  return [...subscriptions].sort((a, b) => {
+    const rankA = statusRank.get(a.status) ?? 99;
+    const rankB = statusRank.get(b.status) ?? 99;
+    if (rankA !== rankB) return rankA - rankB;
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  });
+}
+
+export function createBillingStore(ctx: GenericEndpointContext): BillingStore {
+  return createBillingStoreFromAdapter(ctx.context.adapter);
+}
+
+export function createBillingStoreFromAdapter(adapter: Adapter): BillingStore {
+  const findOne = async <T>(model: string, where: WhereClause): Promise<T | null> =>
+    ((await adapter.findOne<T>({ model, where })) ?? null) as T | null;
+
+  const findMany = async <T>(model: string, where?: WhereClause): Promise<T[]> =>
+    (await adapter.findMany<T>({ model, ...(where ? { where } : {}) })) ?? [];
+
+  return {
+    findSubscriptionById: (id) =>
+      findOne<Subscription>("subscription", [{ field: "id", value: id }]),
+    findSubscriptionByCode: (subscriptionCode) =>
+      findOne<Subscription>("subscription", [
+        { field: "paystackSubscriptionCode", value: subscriptionCode },
+      ]),
+    findSubscriptionsByReference: (referenceId) =>
+      findMany<Subscription>("subscription", [{ field: "referenceId", value: referenceId }]),
+    async findCurrentSubscription(referenceId) {
+      const subscriptions = await this.findSubscriptionsByReference(referenceId);
+      return sortSubscriptionsForCurrent(subscriptions)[0] ?? null;
+    },
+    findSubscriptionsByTransactionReference: (reference) =>
+      findMany<Subscription>("subscription", [
+        { field: "paystackTransactionReference", value: reference },
+      ]),
+    createSubscription: async (data) =>
+      await adapter.create({
+        model: "subscription",
+        data: data as Omit<Subscription, "id">,
+      }),
+    updateSubscription: (id, update) =>
+      adapter.update<Subscription>({
+        model: "subscription",
+        update,
+        where: [{ field: "id", value: id }],
+      }),
+    updateSubscriptionByCode: (subscriptionCode, update) =>
+      adapter.update<Subscription>({
+        model: "subscription",
+        update,
+        where: [{ field: "paystackSubscriptionCode", value: subscriptionCode }],
+      }),
+    createTransaction: async (data) =>
+      await adapter.create({
+        model: "paystackTransaction",
+        data: data as Omit<PaystackTransaction, "id">,
+      }),
+    findTransactionByReference: (reference) =>
+      findOne<PaystackTransaction>("paystackTransaction", [
+        { field: "reference", value: reference },
+      ]),
+    updateTransactionByReference: (reference, update) =>
+      adapter.update<PaystackTransaction>({
+        model: "paystackTransaction",
+        update,
+        where: [{ field: "reference", value: reference }],
+      }),
+    async listTransactions(referenceId) {
+      const transactions = await findMany<PaystackTransaction>("paystackTransaction", [
+        { field: "referenceId", value: referenceId },
+      ]);
+      return transactions.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    },
+    async listProducts() {
+      const products = await findMany<PaystackProduct>("paystackProduct");
+      return products.sort((a, b) => a.name.localeCompare(b.name));
+    },
+    findProductByName: (name) =>
+      findOne<PaystackProduct>("paystackProduct", [{ field: "name", value: name }]),
+    findProductBySlug: (slug) =>
+      findOne<PaystackProduct>("paystackProduct", [{ field: "slug", value: slug }]),
+    async updateProduct(id, update) {
+      await adapter.update({
+        model: "paystackProduct",
+        update,
+        where: [{ field: "id", value: id }],
+      });
+    },
+    async upsertProductByPaystackId(paystackId, data) {
+      const existing = await findOne<PaystackProduct>("paystackProduct", [
+        { field: "paystackId", value: paystackId },
+      ]);
+      if (existing?.id !== undefined) {
+        const { createdAt: _createdAt, ...update } = data;
+        await adapter.update({
+          model: "paystackProduct",
+          update,
+          where: [{ field: "id", value: String(existing.id) }],
+        });
+        return;
+      }
+      await adapter.create({ model: "paystackProduct", data });
+    },
+    listPlans: () => findMany<PaystackPlan>("paystackPlan"),
+    findPlanByName: (name) =>
+      findOne<PaystackPlan>("paystackPlan", [{ field: "name", value: name }]),
+    findPlanByCode: (planCode) =>
+      findOne<PaystackPlan>("paystackPlan", [{ field: "planCode", value: planCode }]),
+    async upsertPlanByPaystackId(paystackId, data) {
+      const existing = await findOne<PaystackPlan>("paystackPlan", [
+        { field: "paystackId", value: paystackId },
+      ]);
+      if (existing?.id !== undefined) {
+        const { createdAt: _createdAt, ...update } = data;
+        await adapter.update({
+          model: "paystackPlan",
+          update,
+          where: [{ field: "id", value: existing.id }],
+        });
+        return;
+      }
+      await adapter.create({ model: "paystackPlan", data });
+    },
+    findUser: (id) => findOne<User>("user", [{ field: "id", value: id }]),
+    findOrganization: (id) =>
+      findOne<PaystackOrganization>("organization", [{ field: "id", value: id }]),
+    findOrganizationOwner: (organizationId) =>
+      findOne<Member>("member", [
+        { field: "organizationId", value: organizationId },
+        { field: "role", value: "owner" },
+      ]),
+    listMembers: (organizationId) =>
+      findMany<Member>("member", [{ field: "organizationId", value: organizationId }]),
+    listTeams: (organizationId) =>
+      findMany("team", [{ field: "organizationId", value: organizationId }]),
+    async saveCustomerCode(referenceId, customerCode, isOrganization) {
+      await adapter.update({
+        model: isOrganization ? "organization" : "user",
+        update: { paystackCustomerCode: customerCode },
+        where: [{ field: "id", value: referenceId }],
+      });
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,12 +32,12 @@ import type {
   PaystackClientLike,
   PaystackOptions,
   PaystackCustomerResponse,
-  Member,
   AnyPaystackOptions,
   User,
 } from "./types";
-import { getPaystackOps, unwrapSdkResult } from "./paystack-sdk";
+import { createPaystackAdapter } from "./paystack-sdk";
 import { PACKAGE_VERSION } from "./version";
+import { createBillingStoreFromAdapter } from "./billing-store";
 
 declare module "better-auth" {
   interface BetterAuthPluginRegistry<AuthOptions, Options> {
@@ -181,22 +181,15 @@ const createPaystackPlugin = <
                     return;
 
                   try {
-                    const paystackOps = getPaystackOps(
+                    const sdkRes = (await createPaystackAdapter(
                       options.paystackClient as PaystackClientLike,
-                    );
-                    if (!paystackOps) return;
-                    const raw =
-                      (await paystackOps.customer?.create({
-                        body: {
-                          email: user.email,
-                          first_name: user.name ?? undefined,
-                          metadata: JSON.stringify({
-                            userId: user.id,
-                          }),
-                        },
-                      })) ??
-                      (await Promise.reject(new Error("Paystack client missing customer ops")));
-                    const sdkRes = unwrapSdkResult<PaystackCustomerResponse>(raw);
+                    ).createCustomer({
+                      email: user.email,
+                      first_name: user.name ?? undefined,
+                      metadata: JSON.stringify({
+                        userId: user.id,
+                      }),
+                    })) as PaystackCustomerResponse;
                     const customerCode = sdkRes?.customer_code;
 
                     if (
@@ -204,13 +197,11 @@ const createPaystackPlugin = <
                       customerCode !== null &&
                       customerCode !== ""
                     ) {
-                      await ctx.adapter.update({
-                        model: "user",
-                        where: [{ field: "id", value: user.id }],
-                        update: {
-                          paystackCustomerCode: customerCode,
-                        },
-                      });
+                      await createBillingStoreFromAdapter(ctx.adapter).saveCustomerCode(
+                        user.id,
+                        customerCode,
+                        false,
+                      );
 
                       if (typeof options.onCustomerCreate === "function") {
                         await options.onCustomerCreate(
@@ -252,18 +243,10 @@ const createPaystackPlugin = <
 
                           let targetEmail = org.email;
                           if (targetEmail === undefined || targetEmail === null) {
-                            const ownerMember = await ctx.adapter.findOne<Member>({
-                              model: "member",
-                              where: [
-                                { field: "organizationId", value: org.id },
-                                { field: "role", value: "owner" },
-                              ],
-                            });
+                            const store = createBillingStoreFromAdapter(ctx.adapter);
+                            const ownerMember = await store.findOrganizationOwner(org.id);
                             if (ownerMember !== null && ownerMember !== undefined) {
-                              const ownerUser = await ctx.adapter.findOne<User>({
-                                model: "user",
-                                where: [{ field: "id", value: ownerMember.userId }],
-                              });
+                              const ownerUser = await store.findUser(ownerMember.userId);
                               targetEmail = ownerUser?.email;
                             }
                           }
@@ -278,18 +261,11 @@ const createPaystackPlugin = <
                             },
                             extraCreateParams,
                           );
-                          const paystackOps = getPaystackOps(
+                          const sdkRes = (await createPaystackAdapter(
                             options.paystackClient as PaystackClientLike,
-                          );
-                          if (!paystackOps) return;
-                          const raw =
-                            (await paystackOps.customer?.create({
-                              body: params as CustomerCreatePayload,
-                            })) ??
-                            (await Promise.reject(
-                              new Error("Paystack client missing customer ops"),
-                            ));
-                          const sdkRes = unwrapSdkResult<PaystackCustomerResponse>(raw);
+                          ).createCustomer(
+                            params as CustomerCreatePayload,
+                          )) as PaystackCustomerResponse;
                           const customerCode = sdkRes?.customer_code as string | undefined;
 
                           if (
@@ -299,13 +275,11 @@ const createPaystackPlugin = <
                             sdkRes !== undefined &&
                             sdkRes !== null
                           ) {
-                            await ctx.adapter.update({
-                              model: "organization",
-                              where: [{ field: "id", value: org.id }],
-                              update: {
-                                paystackCustomerCode: customerCode,
-                              },
-                            });
+                            await createBillingStoreFromAdapter(ctx.adapter).saveCustomerCode(
+                              org.id,
+                              customerCode,
+                              true,
+                            );
 
                             if (typeof options.organization?.onCustomerCreate === "function") {
                               await options.organization.onCustomerCreate(

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -2,16 +2,13 @@ import type { GenericEndpointContext } from "better-auth";
 import { APIError } from "better-auth/api";
 
 import type { Subscription } from "./types";
+import { createBillingStore } from "./billing-store";
 
 export const getOrganizationSubscription = async (
   ctx: GenericEndpointContext,
   organizationId: string,
 ): Promise<Subscription | null> => {
-  const subscription = await ctx.context.adapter.findOne<Subscription>({
-    model: "subscription",
-    where: [{ field: "referenceId", value: organizationId }],
-  });
-  return subscription;
+  return createBillingStore(ctx).findCurrentSubscription(organizationId);
 };
 
 export const checkSeatLimit = async (
@@ -25,10 +22,7 @@ export const checkSeatLimit = async (
     return true; // No explicit seat limit found
   }
 
-  const members = await ctx.context.adapter.findMany({
-    model: "member",
-    where: [{ field: "organizationId", value: organizationId }],
-  });
+  const members = await createBillingStore(ctx).listMembers(organizationId);
 
   if (!subscription) {
     return true; // No subscription, no specific limit enforcement here (or maybe allow depending on config)
@@ -48,10 +42,7 @@ export const checkTeamLimit = async (
   organizationId: string,
   maxTeams: number,
 ): Promise<boolean> => {
-  const teams = await ctx.context.adapter.findMany({
-    model: "team",
-    where: [{ field: "organizationId", value: organizationId }],
-  });
+  const teams = await createBillingStore(ctx).listTeams(organizationId);
 
   if (teams.length >= maxTeams) {
     throw new APIError("FORBIDDEN", {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,33 +1,17 @@
-import { logger } from "better-auth";
 import { APIError, createAuthMiddleware, type AuthMiddleware } from "better-auth/api";
 
 import type { PaystackOptions, Session, User } from "./types";
+import {
+  authorizeBillingReference,
+  type BillingReferenceAction,
+  resolveBillingReferenceId,
+} from "./reference-access";
 
-const BILLING_ORG_ROLES = new Set(["owner", "admin"]);
-
-export function hasBillingRole(role: unknown): boolean {
-  if (Array.isArray(role)) {
-    return role.some((value) => hasBillingRole(value));
-  }
-  if (typeof role !== "string") {
-    return false;
-  }
-  return role
-    .split(",")
-    .map((value) => value.trim())
-    .some((value) => BILLING_ORG_ROLES.has(value));
-}
+export { hasBillingRole } from "./reference-access";
 
 export const referenceMiddleware = (
   options: PaystackOptions,
-  action:
-    | "initialize-transaction"
-    | "verify-transaction"
-    | "list-subscriptions"
-    | "list-transactions"
-    | "disable-subscription"
-    | "enable-subscription"
-    | "get-subscription-manage-link",
+  action: BillingReferenceAction,
 ): AuthMiddleware =>
   createAuthMiddleware(async (ctx) => {
     const session = ctx.context.session as {
@@ -38,85 +22,24 @@ export const referenceMiddleware = (
     if (session === null || session === undefined) {
       throw new APIError("UNAUTHORIZED");
     }
-    const body = (ctx.body ?? {}) as Record<string, unknown>;
-    const query = (ctx.query ?? {}) as Record<string, unknown>;
-    const requestQueryReferenceId =
-      typeof ctx.request?.url === "string"
-        ? (new URL(ctx.request.url).searchParams.get("referenceId") ?? undefined)
-        : undefined;
-    const referenceId =
-      (body.referenceId as string | undefined) ??
-      (query.referenceId as string | undefined) ??
-      requestQueryReferenceId ??
-      session.user.id;
-
-    const subscriptionOptions = options.subscription;
-
-    if (referenceId === session.user.id) {
-      return {
-        context: {
-          ...ctx.context,
-          referenceId,
-        },
-      };
-    }
-
-    // 1. Try custom authorization first if provided
-    if (
-      subscriptionOptions?.enabled === true &&
-      "authorizeReference" in subscriptionOptions &&
-      typeof subscriptionOptions.authorizeReference === "function"
-    ) {
-      const authorized = await subscriptionOptions.authorizeReference(
-        {
-          user: session.user,
-          session: session.session,
-          referenceId,
-          action,
-        },
-        ctx,
-      );
-      if (authorized === true) {
-        return {
-          context: {
-            ...ctx.context,
-            referenceId,
-          },
-        };
-      }
-      // Explicit authorization is authoritative when provided.
-      throw new APIError("UNAUTHORIZED");
-    }
-
-    // 2. Fallback: Organization owner/admin check
-    if (options.organization?.enabled === true) {
-      const member = await ctx.context.adapter.findOne({
-        model: "member",
-        where: [
-          { field: "userId", value: session.user.id },
-          { field: "organizationId", value: referenceId },
-        ],
-      });
-
-      if (
-        member !== null &&
-        member !== undefined &&
-        hasBillingRole((member as { role?: unknown }).role)
-      ) {
-        return {
-          context: {
-            ...ctx.context,
-            referenceId,
-          },
-        };
-      }
-    }
-
-    logger.error(
-      `Passing referenceId into a subscription action isn't allowed unless subscription.authorizeReference allows it or the session user is an organization owner/admin.`,
-    );
-    throw new APIError("BAD_REQUEST", {
-      message:
-        "Passing referenceId isn't allowed without subscription.authorizeReference or organization owner/admin membership.",
+    const referenceId = resolveBillingReferenceId({
+      body: ctx.body,
+      query: ctx.query,
+      requestUrl: ctx.request?.url,
+      fallbackUserId: session.user.id,
     });
+
+    await authorizeBillingReference(ctx, options, {
+      user: session.user,
+      session: session.session,
+      referenceId,
+      action,
+    });
+
+    return {
+      context: {
+        ...ctx.context,
+        referenceId,
+      },
+    };
   });

--- a/src/operations.ts
+++ b/src/operations.ts
@@ -1,30 +1,25 @@
 import { APIError } from "better-auth/api";
 import type { GenericEndpointContext } from "better-auth";
-import type { components } from "@alexasomba/paystack-node";
 
-import { getPaystackOps, unwrapSdkResult } from "./paystack-sdk";
+import { createBillingStore } from "./billing-store";
+import { createPaystackAdapter } from "./paystack-sdk";
 import { getNextPeriodEnd, getPlans, validateMinAmount } from "./utils";
 import type {
   AnyPaystackOptions,
   ChargeRecurringSubscriptionInput,
   ChargeRecurringSubscriptionResult,
-  Member,
-  PaystackPlan,
-  PaystackProduct,
   PaystackSyncResult,
   PaystackChargeAuthorizationResponse,
-  Subscription,
-  User,
 } from "./types";
 
 export async function syncPaystackProducts(
   ctx: GenericEndpointContext,
   options: AnyPaystackOptions,
 ): Promise<PaystackSyncResult> {
-  const paystack = getPaystackOps(options.paystackClient);
+  const paystack = createPaystackAdapter(options.paystackClient);
+  const store = createBillingStore(ctx);
   try {
-    const raw = await paystack?.product?.list({});
-    const productsData = unwrapSdkResult<components["schemas"]["ProductListsResponseArray"][]>(raw);
+    const productsData = await paystack.listProducts();
 
     if (!Array.isArray(productsData)) {
       return { status: "success", count: 0 };
@@ -32,11 +27,6 @@ export async function syncPaystackProducts(
 
     for (const product of productsData) {
       const paystackId = String(product.id);
-      const existing = await ctx.context.adapter.findOne<PaystackProduct>({
-        model: "paystackProduct",
-        where: [{ field: "paystackId", value: paystackId }],
-      });
-
       const productFields = {
         name: product.name ?? "",
         description: product.description ?? "",
@@ -60,18 +50,10 @@ export async function syncPaystackProducts(
         updatedAt: new Date(),
       };
 
-      if (existing !== undefined && existing !== null) {
-        await ctx.context.adapter.update({
-          model: "paystackProduct",
-          update: productFields,
-          where: [{ field: "id", value: String(existing.id) }],
-        });
-      } else {
-        await ctx.context.adapter.create({
-          model: "paystackProduct",
-          data: { ...productFields, createdAt: new Date() },
-        });
-      }
+      await store.upsertProductByPaystackId(paystackId, {
+        ...productFields,
+        createdAt: new Date(),
+      });
     }
 
     return { status: "success", count: productsData.length };
@@ -88,10 +70,10 @@ export async function syncPaystackPlans(
   ctx: GenericEndpointContext,
   options: AnyPaystackOptions,
 ): Promise<PaystackSyncResult> {
-  const paystack = getPaystackOps(options.paystackClient);
+  const paystack = createPaystackAdapter(options.paystackClient);
+  const store = createBillingStore(ctx);
   try {
-    const raw = await paystack?.plan?.list();
-    const plansData = unwrapSdkResult<components["schemas"]["PlanListResponseArray"][]>(raw);
+    const plansData = await paystack.listPlans();
 
     if (!Array.isArray(plansData)) {
       return { status: "success", count: 0 };
@@ -99,14 +81,9 @@ export async function syncPaystackPlans(
 
     for (const plan of plansData) {
       const paystackId = String(plan.id);
-      const existing = await ctx.context.adapter.findOne<PaystackPlan>({
-        model: "paystackPlan",
-        where: [{ field: "paystackId", value: paystackId }],
-      });
-
       const planData = {
         name: plan.name ?? "",
-        description: plan.description ?? "",
+        description: typeof plan.description === "string" ? plan.description : "",
         amount: plan.amount ?? 0,
         currency: plan.currency ?? "",
         interval: plan.interval ?? "",
@@ -120,18 +97,10 @@ export async function syncPaystackPlans(
         updatedAt: new Date(),
       };
 
-      if (existing !== undefined && existing !== null) {
-        await ctx.context.adapter.update({
-          model: "paystackPlan",
-          update: planData,
-          where: [{ field: "id", value: existing.id! }],
-        });
-      } else {
-        await ctx.context.adapter.create({
-          model: "paystackPlan",
-          data: { ...planData, createdAt: new Date() },
-        });
-      }
+      await store.upsertPlanByPaystackId(paystackId, {
+        ...planData,
+        createdAt: new Date(),
+      });
     }
 
     return { status: "success", count: plansData.length };
@@ -150,10 +119,8 @@ export async function chargeSubscriptionRenewal(
   input: ChargeRecurringSubscriptionInput,
 ): Promise<ChargeRecurringSubscriptionResult> {
   const { subscriptionId, amount: bodyAmount } = input;
-  const subscription = await ctx.context.adapter.findOne<Subscription>({
-    model: "subscription",
-    where: [{ field: "id", value: subscriptionId }],
-  });
+  const store = createBillingStore(ctx);
+  const subscription = await store.findSubscriptionById(subscriptionId);
 
   if (subscription === undefined || subscription === null) {
     throw new APIError("NOT_FOUND", { message: "Subscription not found" });
@@ -187,26 +154,14 @@ export async function chargeSubscriptionRenewal(
   let billingUserId = subscription.userId;
   const referenceId = subscription.referenceId;
   if (referenceId !== undefined && referenceId !== null && referenceId !== "") {
-    const user = await ctx.context.adapter.findOne<User>({
-      model: "user",
-      where: [{ field: "id", value: referenceId }],
-    });
+    const user = await store.findUser(referenceId);
     if (user !== undefined && user !== null) {
       email = user.email;
       billingUserId = user.id;
     } else if (options.organization?.enabled === true) {
-      const ownerMember = await ctx.context.adapter.findOne<Member>({
-        model: "member",
-        where: [
-          { field: "organizationId", value: referenceId },
-          { field: "role", value: "owner" },
-        ],
-      });
+      const ownerMember = await store.findOrganizationOwner(referenceId);
       if (ownerMember !== undefined && ownerMember !== null) {
-        const ownerUser = await ctx.context.adapter.findOne<User>({
-          model: "user",
-          where: [{ field: "id", value: ownerMember.userId }],
-        });
+        const ownerUser = await store.findUser(ownerMember.userId);
         email = ownerUser?.email;
         billingUserId = ownerUser?.id ?? ownerMember.userId;
       }
@@ -225,60 +180,53 @@ export async function chargeSubscriptionRenewal(
     });
   }
 
-  const paystack = getPaystackOps(options.paystackClient);
-  const chargeResRaw = await paystack?.transaction?.chargeAuthorization({
-    body: {
-      email,
-      amount,
-      authorization_code: subscription.paystackAuthorizationCode,
-      reference: `rec_${subscription.id}_${Date.now()}`,
-      metadata: JSON.stringify({
-        subscriptionId,
-        referenceId,
-      }),
-    },
+  const paystack = createPaystackAdapter(options.paystackClient);
+  const chargeData = await paystack.chargeAuthorization({
+    email,
+    amount,
+    authorization_code: subscription.paystackAuthorizationCode,
+    reference: `rec_${subscription.id}_${Date.now()}`,
+    metadata: JSON.stringify({
+      subscriptionId,
+      referenceId,
+    }),
   });
 
-  const chargeData = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
-  if (chargeData?.status === "success" && chargeData.reference !== undefined) {
+  const typedChargeData = chargeData as PaystackChargeAuthorizationResponse;
+  if (typedChargeData?.status === "success" && typedChargeData.reference !== undefined) {
     const now = new Date();
     const nextPeriodEnd = getNextPeriodEnd(now, plan.interval ?? "monthly");
 
-    await ctx.context.adapter.create({
-      model: "paystackTransaction",
-      data: {
-        reference: chargeData.reference,
-        paystackId:
-          chargeData.id !== undefined && chargeData.id !== null ? String(chargeData.id) : undefined,
+    await store.createTransaction({
+      reference: typedChargeData.reference,
+      paystackId:
+        typedChargeData.id !== undefined && typedChargeData.id !== null
+          ? String(typedChargeData.id)
+          : undefined,
+      referenceId,
+      userId: billingUserId,
+      amount: typedChargeData.amount,
+      currency: typedChargeData.currency,
+      status: "success",
+      plan: plan.name.toLowerCase(),
+      metadata: JSON.stringify({
+        type: "renewal",
+        subscriptionId,
         referenceId,
-        userId: billingUserId,
-        amount: chargeData.amount,
-        currency: chargeData.currency,
-        status: "success",
-        plan: plan.name.toLowerCase(),
-        metadata: JSON.stringify({
-          type: "renewal",
-          subscriptionId,
-          referenceId,
-        }),
-        createdAt: now,
-        updatedAt: now,
-      },
+      }),
+      createdAt: now,
+      updatedAt: now,
     });
 
-    await ctx.context.adapter.update({
-      model: "subscription",
-      update: {
-        periodStart: now,
-        periodEnd: nextPeriodEnd,
-        updatedAt: now,
-        paystackTransactionReference: chargeData.reference,
-      },
-      where: [{ field: "id", value: subscription.id }],
+    await store.updateSubscription(subscription.id, {
+      periodStart: now,
+      periodEnd: nextPeriodEnd,
+      updatedAt: now,
+      paystackTransactionReference: typedChargeData.reference,
     });
 
-    return { status: "success", data: chargeData };
+    return { status: "success", data: typedChargeData };
   }
 
-  return { status: "failed", data: chargeData };
+  return { status: "failed", data: typedChargeData };
 }

--- a/src/paystack-sdk.ts
+++ b/src/paystack-sdk.ts
@@ -79,7 +79,39 @@ export function getPaystackOps(client?: PaystackClientLike): PaystackClientLike 
   return client;
 }
 
-export function createPaystackAdapter(client?: PaystackClientLike) {
+interface ChargeAuthorizationPayload {
+  email: string;
+  amount: number;
+  authorization_code: string;
+  reference: string;
+  metadata?: string;
+}
+
+interface CreateSubscriptionPayload {
+  customer: string;
+  plan: string;
+  authorization?: string;
+  start_date?: string;
+}
+
+export interface PaystackAdapter {
+  initializeTransaction(
+    body: components["schemas"]["TransactionInitialize"],
+  ): Promise<components["schemas"]["TransactionInitializeResponse"]["data"]>;
+  verifyTransaction(reference: string): Promise<unknown>;
+  chargeAuthorization(body: ChargeAuthorizationPayload): Promise<unknown>;
+  createCustomer(body: CustomerCreatePayload): Promise<unknown>;
+  listProducts(): Promise<components["schemas"]["ProductListsResponseArray"][]>;
+  fetchProduct(productId: number): Promise<unknown>;
+  listPlans(): Promise<components["schemas"]["PlanListResponseArray"][]>;
+  createSubscription(body: CreateSubscriptionPayload): Promise<unknown>;
+  fetchSubscription(subscriptionCode: string): Promise<unknown>;
+  disableSubscription(body: { code: string; token: string }): Promise<unknown>;
+  enableSubscription(body: { code: string; token: string }): Promise<unknown>;
+  manageSubscriptionLink(subscriptionCode: string): Promise<{ link: string }>;
+}
+
+export function createPaystackAdapter(client?: PaystackClientLike): PaystackAdapter {
   const requireClient = (): PaystackClientLike => {
     if (client === undefined || client === null) {
       throw new APIError("BAD_REQUEST", { message: "Paystack client is not configured" });
@@ -88,62 +120,53 @@ export function createPaystackAdapter(client?: PaystackClientLike) {
   };
 
   return {
-    async initializeTransaction(body: components["schemas"]["TransactionInitialize"]) {
+    async initializeTransaction(
+      body: components["schemas"]["TransactionInitialize"],
+    ): Promise<components["schemas"]["TransactionInitializeResponse"]["data"]> {
       const raw = await requireClient().transaction?.initialize({ body });
       return unwrapSdkResult<components["schemas"]["TransactionInitializeResponse"]["data"]>(raw);
     },
-    async verifyTransaction(reference: string) {
+    async verifyTransaction(reference: string): Promise<unknown> {
       const raw = await requireClient().transaction?.verify(reference);
       return unwrapSdkResult(raw);
     },
-    async chargeAuthorization(body: {
-      email: string;
-      amount: number;
-      authorization_code: string;
-      reference: string;
-      metadata?: string;
-    }) {
+    async chargeAuthorization(body: ChargeAuthorizationPayload): Promise<unknown> {
       const raw = await requireClient().transaction?.chargeAuthorization({ body });
       return unwrapSdkResult(raw);
     },
-    async createCustomer(body: CustomerCreatePayload) {
+    async createCustomer(body: CustomerCreatePayload): Promise<unknown> {
       const raw = await requireClient().customer?.create({ body });
       return unwrapSdkResult(raw);
     },
-    async listProducts() {
+    async listProducts(): Promise<components["schemas"]["ProductListsResponseArray"][]> {
       const raw = await requireClient().product?.list({});
       return unwrapSdkResult<components["schemas"]["ProductListsResponseArray"][]>(raw);
     },
-    async fetchProduct(productId: number) {
+    async fetchProduct(productId: number): Promise<unknown> {
       const raw = await requireClient().product?.fetch(productId);
       return unwrapSdkResult(raw);
     },
-    async listPlans() {
+    async listPlans(): Promise<components["schemas"]["PlanListResponseArray"][]> {
       const raw = await requireClient().plan?.list();
       return unwrapSdkResult<components["schemas"]["PlanListResponseArray"][]>(raw);
     },
-    async createSubscription(body: {
-      customer: string;
-      plan: string;
-      authorization?: string;
-      start_date?: string;
-    }) {
+    async createSubscription(body: CreateSubscriptionPayload): Promise<unknown> {
       const raw = await requireClient().subscription?.create({ body });
       return unwrapSdkResult(raw);
     },
-    async fetchSubscription(subscriptionCode: string) {
+    async fetchSubscription(subscriptionCode: string): Promise<unknown> {
       const raw = await requireClient().subscription?.fetch(subscriptionCode);
       return unwrapSdkResult(raw);
     },
-    async disableSubscription(body: { code: string; token: string }) {
+    async disableSubscription(body: { code: string; token: string }): Promise<unknown> {
       const raw = await requireClient().subscription?.disable({ body });
       return unwrapSdkResult(raw);
     },
-    async enableSubscription(body: { code: string; token: string }) {
+    async enableSubscription(body: { code: string; token: string }): Promise<unknown> {
       const raw = await requireClient().subscription?.enable({ body });
       return unwrapSdkResult(raw);
     },
-    async manageSubscriptionLink(subscriptionCode: string) {
+    async manageSubscriptionLink(subscriptionCode: string): Promise<{ link: string }> {
       const raw = await requireClient().subscription?.manageLink(subscriptionCode);
       return unwrapSdkResult<{ link: string }>(raw);
     },

--- a/src/paystack-sdk.ts
+++ b/src/paystack-sdk.ts
@@ -1,5 +1,10 @@
 import { APIError } from "better-auth/api";
-import { PaystackError, PaystackResponse } from "@alexasomba/paystack-node";
+import {
+  PaystackError,
+  PaystackResponse,
+  type CustomerCreatePayload,
+} from "@alexasomba/paystack-node";
+import type { components } from "@alexasomba/paystack-node";
 import type { PaystackClientLike } from "./types";
 
 /**
@@ -72,4 +77,75 @@ export function unwrapSdkResult<T = unknown>(result: unknown): T {
  */
 export function getPaystackOps(client?: PaystackClientLike): PaystackClientLike | undefined {
   return client;
+}
+
+export function createPaystackAdapter(client?: PaystackClientLike) {
+  const requireClient = (): PaystackClientLike => {
+    if (client === undefined || client === null) {
+      throw new APIError("BAD_REQUEST", { message: "Paystack client is not configured" });
+    }
+    return client;
+  };
+
+  return {
+    async initializeTransaction(body: components["schemas"]["TransactionInitialize"]) {
+      const raw = await requireClient().transaction?.initialize({ body });
+      return unwrapSdkResult<components["schemas"]["TransactionInitializeResponse"]["data"]>(raw);
+    },
+    async verifyTransaction(reference: string) {
+      const raw = await requireClient().transaction?.verify(reference);
+      return unwrapSdkResult(raw);
+    },
+    async chargeAuthorization(body: {
+      email: string;
+      amount: number;
+      authorization_code: string;
+      reference: string;
+      metadata?: string;
+    }) {
+      const raw = await requireClient().transaction?.chargeAuthorization({ body });
+      return unwrapSdkResult(raw);
+    },
+    async createCustomer(body: CustomerCreatePayload) {
+      const raw = await requireClient().customer?.create({ body });
+      return unwrapSdkResult(raw);
+    },
+    async listProducts() {
+      const raw = await requireClient().product?.list({});
+      return unwrapSdkResult<components["schemas"]["ProductListsResponseArray"][]>(raw);
+    },
+    async fetchProduct(productId: number) {
+      const raw = await requireClient().product?.fetch(productId);
+      return unwrapSdkResult(raw);
+    },
+    async listPlans() {
+      const raw = await requireClient().plan?.list();
+      return unwrapSdkResult<components["schemas"]["PlanListResponseArray"][]>(raw);
+    },
+    async createSubscription(body: {
+      customer: string;
+      plan: string;
+      authorization?: string;
+      start_date?: string;
+    }) {
+      const raw = await requireClient().subscription?.create({ body });
+      return unwrapSdkResult(raw);
+    },
+    async fetchSubscription(subscriptionCode: string) {
+      const raw = await requireClient().subscription?.fetch(subscriptionCode);
+      return unwrapSdkResult(raw);
+    },
+    async disableSubscription(body: { code: string; token: string }) {
+      const raw = await requireClient().subscription?.disable({ body });
+      return unwrapSdkResult(raw);
+    },
+    async enableSubscription(body: { code: string; token: string }) {
+      const raw = await requireClient().subscription?.enable({ body });
+      return unwrapSdkResult(raw);
+    },
+    async manageSubscriptionLink(subscriptionCode: string) {
+      const raw = await requireClient().subscription?.manageLink(subscriptionCode);
+      return unwrapSdkResult<{ link: string }>(raw);
+    },
+  };
 }

--- a/src/reference-access.ts
+++ b/src/reference-access.ts
@@ -1,0 +1,99 @@
+import type { GenericEndpointContext } from "better-auth";
+import { APIError } from "better-auth/api";
+
+import type { AnyPaystackOptions, Session, User } from "./types";
+
+export type BillingReferenceAction =
+  | "initialize-transaction"
+  | "verify-transaction"
+  | "list-subscriptions"
+  | "list-transactions"
+  | "disable-subscription"
+  | "enable-subscription"
+  | "get-subscription-manage-link";
+
+const BILLING_ORG_ROLES = new Set(["owner", "admin"]);
+
+export function hasBillingRole(role: unknown): boolean {
+  if (Array.isArray(role)) {
+    return role.some((value) => hasBillingRole(value));
+  }
+  if (typeof role !== "string") {
+    return false;
+  }
+  return role
+    .split(",")
+    .map((value) => value.trim())
+    .some((value) => BILLING_ORG_ROLES.has(value));
+}
+
+export function resolveBillingReferenceId(input: {
+  body?: unknown;
+  query?: unknown;
+  requestUrl?: string;
+  fallbackUserId: string;
+}): string {
+  const body = (input.body ?? {}) as Record<string, unknown>;
+  const query = (input.query ?? {}) as Record<string, unknown>;
+  const requestQueryReferenceId =
+    typeof input.requestUrl === "string"
+      ? (new URL(input.requestUrl).searchParams.get("referenceId") ?? undefined)
+      : undefined;
+
+  return (
+    (body.referenceId as string | undefined) ??
+    (query.referenceId as string | undefined) ??
+    requestQueryReferenceId ??
+    input.fallbackUserId
+  );
+}
+
+export async function authorizeBillingReference(
+  ctx: GenericEndpointContext,
+  options: AnyPaystackOptions,
+  data: {
+    user: User;
+    session: Session;
+    referenceId: string;
+    action: BillingReferenceAction;
+  },
+): Promise<void> {
+  if (data.referenceId === data.user.id) return;
+
+  if (
+    options.subscription?.enabled === true &&
+    typeof options.subscription.authorizeReference === "function"
+  ) {
+    const authorized = await options.subscription.authorizeReference(
+      {
+        user: data.user,
+        session: data.session,
+        referenceId: data.referenceId,
+        action: data.action,
+      },
+      ctx,
+    );
+    if (authorized === true) return;
+    throw new APIError("UNAUTHORIZED");
+  }
+
+  if (options.organization?.enabled === true) {
+    const member = await ctx.context.adapter.findOne({
+      model: "member",
+      where: [
+        { field: "userId", value: data.user.id },
+        { field: "organizationId", value: data.referenceId },
+      ],
+    });
+
+    if (
+      member !== null &&
+      member !== undefined &&
+      hasBillingRole((member as { role?: unknown }).role)
+    ) {
+      return;
+    }
+  }
+
+  throw new APIError("UNAUTHORIZED");
+}

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,9 +23,6 @@ import type {
   PaystackPlan,
   PaystackWebhookPayload,
   PaystackTransactionResponse,
-  PaystackChargeAuthorizationResponse,
-  ChargeRecurringSubscriptionResult,
-  Session,
   User,
   PaystackUser,
   PaystackCheckoutChannel,
@@ -36,16 +33,16 @@ import {
   getPlans,
   getProductByName,
   getProducts,
-  validateMinAmount,
-  getNextPeriodEnd,
   getPlanSeatAmount,
   calculatePlanAmount,
-  assertLocallyManagedSubscription,
   isLocalSubscriptionCode,
 } from "./utils";
-import { hasBillingRole, referenceMiddleware } from "./middleware";
+import { referenceMiddleware } from "./middleware";
+import { authorizeBillingReference } from "./reference-access";
 import { getPaystackOps, unwrapSdkResult } from "./paystack-sdk";
 import { getOrganizationSubscription } from "./limits";
+import { createBillingStore } from "./billing-store";
+import { handleProratedUpgrade } from "./subscription-lifecycle";
 
 const PAYSTACK_ERROR_CODES: {
   SUBSCRIPTION_NOT_FOUND: RawError<"SUBSCRIPTION_NOT_FOUND">;
@@ -83,44 +80,6 @@ function isAllowedSubscriptionChannel(
 ): boolean {
   if (allowedChannels === undefined) return true;
   return channel !== undefined && channel !== null && allowedChannels.includes(channel as never);
-}
-
-async function assertReferenceAccess(
-  ctx: GenericEndpointContext,
-  options: AnyPaystackOptions,
-  data: { user: User; session: Session; referenceId: string; action: string },
-): Promise<void> {
-  if (data.referenceId === data.user.id) return;
-
-  if (
-    options.subscription?.enabled === true &&
-    typeof options.subscription.authorizeReference === "function"
-  ) {
-    const authorized = await options.subscription.authorizeReference(
-      {
-        user: data.user,
-        session: data.session,
-        referenceId: data.referenceId,
-        action: data.action,
-      },
-      ctx,
-    );
-    if (authorized === true) return;
-    throw new APIError("UNAUTHORIZED");
-  }
-
-  if (options.organization?.enabled === true) {
-    const member = await ctx.context.adapter.findOne<Member>({
-      model: "member",
-      where: [
-        { field: "userId", value: data.user.id },
-        { field: "organizationId", value: data.referenceId },
-      ],
-    });
-    if (member !== null && member !== undefined && hasBillingRole(member.role)) return;
-  }
-
-  throw new APIError("UNAUTHORIZED");
 }
 
 async function hmacSha512Hex(secret: string, message: string): Promise<string> {
@@ -927,207 +886,32 @@ export const initializeTransaction = <P extends string = "/initialize-transactio
 
         // Handle prorateAndCharge for existing active subscriptions
         if (plan !== undefined && prorateAndCharge === true) {
-          const existingSub = await getOrganizationSubscription(ctx, referenceId);
-          if (
-            existingSub?.status === "active" &&
-            existingSub.paystackSubscriptionCode !== undefined &&
-            existingSub.paystackSubscriptionCode !== null &&
-            existingSub.paystackSubscriptionCode !== ""
-          ) {
-            if (
-              existingSub.periodEnd !== undefined &&
-              existingSub.periodEnd !== null &&
-              existingSub.periodStart !== undefined &&
-              existingSub.periodStart !== null
-            ) {
-              // 1. Calculate remaining days
-              const now = new Date();
-              const periodEndLocal = new Date(existingSub.periodEnd);
-              const periodStartLocal = new Date(existingSub.periodStart);
+          const proration = await handleProratedUpgrade(ctx, options, {
+            plan,
+            referenceId,
+            quantity,
+            targetEmail,
+            userId: user.id,
+            finalCurrency,
+            callbackURL,
+            allowedSubscriptionChannels,
+          });
 
-              const totalDays = Math.max(
-                1,
-                Math.ceil(
-                  (periodEndLocal.getTime() - periodStartLocal.getTime()) / (1000 * 60 * 60 * 24),
-                ),
-              );
-              const remainingDays = Math.max(
-                0,
-                Math.ceil((periodEndLocal.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)),
-              );
+          if (proration?.kind === "checkout") {
+            return ctx.json({
+              url: proration.url ?? "",
+              reference: proration.reference ?? "",
+              accessCode: proration.accessCode ?? "",
+              redirect: proration.redirect,
+            });
+          }
 
-              // 2. Fetch old plan/amount
-              let oldAmount = 0;
-              if (existingSub.plan !== "") {
-                const oldPlan =
-                  (await getPlanByName(options, existingSub.plan)) ??
-                  (await ctx.context.adapter.findOne<PaystackPlan>({
-                    model: "paystackPlan",
-                    where: [{ field: "name", value: existingSub.plan }],
-                  })) ??
-                  undefined;
-                if (oldPlan !== undefined && oldPlan !== null) {
-                  const oldSeatCount = existingSub.seats;
-                  oldAmount = calculatePlanAmount(oldPlan, oldSeatCount);
-                }
-              }
-
-              // 3. Calculate new total amount
-              let membersCount = 1;
-              let newSeatCount = quantity ?? existingSub.seats ?? membersCount;
-              let newAmount: number;
-              try {
-                assertLocallyManagedSubscription(existingSub, "plan or seat changes");
-                if (getPlanSeatAmount(plan) !== undefined) {
-                  const members = await ctx.context.adapter.findMany<Member>({
-                    model: "member",
-                    where: [{ field: "organizationId", value: referenceId }],
-                  });
-                  membersCount = members.length > 0 ? members.length : 1;
-                }
-                newSeatCount = quantity ?? existingSub.seats ?? membersCount;
-                newAmount = calculatePlanAmount(plan, newSeatCount);
-              } catch (error: unknown) {
-                throw new APIError("BAD_REQUEST", {
-                  message:
-                    error instanceof Error ? error.message : "Invalid seat configuration for plan.",
-                });
-              }
-
-              // 4. Calculate Difference & Charge
-              const costDifference = newAmount - oldAmount;
-              const prorationMetadata = {
-                type: "proration",
-                subscriptionId: existingSub.id,
-                referenceId,
-                newPlan: plan.name.toLowerCase(),
-                oldPlan: existingSub.plan,
-                newSeatCount,
-                remainingDays,
-              };
-              let completedProrationReference: string | undefined;
-
-              if (costDifference > 0 && remainingDays > 0) {
-                const proratedAmount = Math.round((costDifference / totalDays) * remainingDays);
-                if (proratedAmount < 5000) {
-                  throw new APIError("BAD_REQUEST", {
-                    message:
-                      "Prorated upgrade amount is below Paystack's minimum charge. Schedule the change for period end instead.",
-                    status: 400,
-                  });
-                }
-
-                const ops = getPaystackOps(options.paystackClient);
-                if (ops === undefined || ops === null) {
-                  ctx.context.logger.error("Paystack client not configured for proration charge");
-                  return;
-                }
-
-                if (
-                  existingSub.paystackAuthorizationCode !== undefined &&
-                  existingSub.paystackAuthorizationCode !== null &&
-                  existingSub.paystackAuthorizationCode !== ""
-                ) {
-                  const chargeResRaw = await ops.transaction?.chargeAuthorization({
-                    body: {
-                      email: targetEmail,
-                      amount: proratedAmount,
-                      authorization_code: existingSub.paystackAuthorizationCode,
-                      reference: `upg_${existingSub.id}_${Date.now()}_${Math.random().toString(36).substring(7)}`,
-                      metadata: JSON.stringify(prorationMetadata),
-                    },
-                  });
-                  const sdkRes = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
-
-                  if (sdkRes?.status !== "success") {
-                    throw new APIError("BAD_REQUEST", {
-                      message: "Failed to process prorated charge via saved authorization.",
-                    });
-                  }
-
-                  await ctx.context.adapter.create({
-                    model: "paystackTransaction",
-                    data: {
-                      reference: sdkRes.reference ?? "",
-                      paystackId:
-                        sdkRes.id !== undefined && sdkRes.id !== null
-                          ? String(sdkRes.id)
-                          : undefined,
-                      referenceId,
-                      userId: user.id,
-                      amount: sdkRes.amount ?? proratedAmount,
-                      currency: sdkRes.currency ?? finalCurrency,
-                      status: "success",
-                      plan: plan.name.toLowerCase(),
-                      metadata: JSON.stringify(prorationMetadata),
-                      createdAt: new Date(),
-                      updatedAt: new Date(),
-                    },
-                  });
-                  completedProrationReference = sdkRes.reference ?? undefined;
-                } else {
-                  const initRaw = await ops.transaction?.initialize({
-                    body: {
-                      email: targetEmail,
-                      amount: proratedAmount,
-                      currency: finalCurrency,
-                      callback_url: callbackURL ?? undefined,
-                      metadata: JSON.stringify(prorationMetadata),
-                      ...(allowedSubscriptionChannels !== undefined
-                        ? { channels: allowedSubscriptionChannels }
-                        : {}),
-                    } as components["schemas"]["TransactionInitialize"],
-                  });
-                  const initRes =
-                    unwrapSdkResult<components["schemas"]["TransactionInitializeResponse"]["data"]>(
-                      initRaw,
-                    );
-
-                  await ctx.context.adapter.create({
-                    model: "paystackTransaction",
-                    data: {
-                      reference: initRes?.reference ?? "",
-                      referenceId,
-                      userId: user.id,
-                      amount: proratedAmount,
-                      currency: finalCurrency,
-                      status: "pending",
-                      plan: plan.name.toLowerCase(),
-                      metadata: JSON.stringify(prorationMetadata),
-                      createdAt: new Date(),
-                      updatedAt: new Date(),
-                    },
-                  });
-
-                  return ctx.json({
-                    url: initRes?.authorization_url,
-                    reference: initRes?.reference,
-                    accessCode: initRes?.access_code,
-                    redirect: true,
-                  });
-                }
-              }
-
-              // 5. Update Local DB for locally managed subscriptions.
-              await ctx.context.adapter.update({
-                model: "subscription",
-                where: [{ field: "id", value: existingSub.id }],
-                update: {
-                  plan: plan.name,
-                  seats: newSeatCount,
-                  ...(completedProrationReference !== undefined
-                    ? { paystackTransactionReference: completedProrationReference }
-                    : {}),
-                  updatedAt: new Date(),
-                },
-              });
-
-              return ctx.json({
-                status: "success",
-                message: "Subscription successfully upgraded with prorated charge.",
-                prorated: true,
-              });
-            }
+          if (proration?.kind === "completed") {
+            return ctx.json({
+              status: proration.status,
+              message: proration.message,
+              prorated: proration.prorated,
+            });
           }
         }
 
@@ -1640,33 +1424,12 @@ export const verifyTransaction = <P extends string = "/verify-transaction">(
           referenceId !== "" &&
           referenceId !== session.user.id
         ) {
-          const authRef = subscriptionOptions?.authorizeReference;
-          let authorized = false;
-          if (authRef !== undefined && authRef !== null) {
-            authorized = await authRef(
-              {
-                user: session.user,
-                session: session.session,
-                referenceId,
-                action: "verify-transaction",
-              },
-              ctx as GenericEndpointContext,
-            );
-          }
-          if (authorized === false && options.organization?.enabled === true) {
-            const member = await ctx.context.adapter.findOne<Member>({
-              model: "member",
-              where: [
-                { field: "userId", value: session.user.id },
-                { field: "organizationId", value: referenceId },
-              ],
-            });
-            if (member !== undefined && member !== null) authorized = true;
-          }
-
-          if (authorized === false) {
-            throw new APIError("UNAUTHORIZED");
-          }
+          await authorizeBillingReference(ctx as GenericEndpointContext, options, {
+            user: session.user as User,
+            session: session.session,
+            referenceId,
+            action: "verify-transaction",
+          });
         }
 
         try {
@@ -1960,6 +1723,7 @@ export const listSubscriptions = <P extends string = "/list-subscriptions">(
       }
       const session = await getSessionFromCtx(ctx);
       if (session === undefined || session === null) throw new APIError("UNAUTHORIZED");
+      const store = createBillingStore(ctx);
       const referenceIdPart = (ctx.context as Record<string, unknown>).referenceId as
         | string
         | undefined;
@@ -1970,18 +1734,15 @@ export const listSubscriptions = <P extends string = "/list-subscriptions">(
           : undefined);
       const userId = (session.user as { id: string }).id;
       if (queryRefId !== undefined && queryRefId !== userId && referenceIdPart !== queryRefId) {
-        await assertReferenceAccess(ctx, options, {
+        await authorizeBillingReference(ctx, options, {
           user: session.user as User,
-          session: session.session as Session,
+          session: session.session,
           referenceId: queryRefId,
           action: "list-subscriptions",
         });
       }
       const referenceId = queryRefId ?? referenceIdPart ?? userId;
-      const res = await ctx.context.adapter.findMany<Subscription>({
-        model: "subscription",
-        where: [{ field: "referenceId", value: referenceId }],
-      });
+      const res = await store.findSubscriptionsByReference(referenceId);
       return ctx.json({ subscriptions: res });
     },
   );
@@ -2031,6 +1792,7 @@ export const listTransactions = <P extends string = "/list-transactions">(
     async (ctx) => {
       const session = await getSessionFromCtx(ctx);
       if (session === undefined || session === null) throw new APIError("UNAUTHORIZED");
+      const store = createBillingStore(ctx);
       const referenceIdPart = (ctx.context as Record<string, unknown>).referenceId as
         | string
         | undefined;
@@ -2041,21 +1803,16 @@ export const listTransactions = <P extends string = "/list-transactions">(
           : undefined);
       const userId = (session.user as { id: string }).id;
       if (queryRefId !== undefined && queryRefId !== userId && referenceIdPart !== queryRefId) {
-        await assertReferenceAccess(ctx, options, {
+        await authorizeBillingReference(ctx, options, {
           user: session.user as User,
-          session: session.session as Session,
+          session: session.session,
           referenceId: queryRefId,
           action: "list-transactions",
         });
       }
       const referenceId = queryRefId ?? referenceIdPart ?? userId;
-      const res = await ctx.context.adapter.findMany<PaystackTransaction>({
-        model: "paystackTransaction",
-        where: [{ field: "referenceId", value: referenceId }],
-      });
-      // Sort by createdAt desc locally.
-      const sorted = res.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-      return ctx.json({ transactions: sorted });
+      const transactions = await store.listTransactions(referenceId);
+      return ctx.json({ transactions });
     },
   );
 };
@@ -2409,124 +2166,6 @@ export const getSubscriptionManageLink = <P extends string = "/subscription-mana
   );
 };
 
-export const syncProducts = <P extends string = "/sync-products">(
-  options: AnyPaystackOptions,
-  path: P = "/sync-products" as P,
-): StrictEndpoint<
-  P,
-  {
-    method: "POST";
-    metadata: {
-      scope: "server";
-    };
-    disableBody: true;
-    use: ((inputContext: MiddlewareInputContext<MiddlewareOptions>) => Promise<{
-      session: {
-        session: Record<string, unknown> & {
-          id: string;
-          createdAt: Date;
-          updatedAt: Date;
-          userId: string;
-          expiresAt: Date;
-          token: string;
-          ipAddress?: string | null | undefined;
-          userAgent?: string | null | undefined;
-        };
-        user: Record<string, unknown> & {
-          id: string;
-          createdAt: Date;
-          updatedAt: Date;
-          email: string;
-          emailVerified: boolean;
-          name: string;
-          image?: string | null | undefined;
-        };
-      };
-    }>)[];
-  },
-  | {
-      products: never[];
-    }
-  | {
-      status: string;
-      count: number;
-    }
-> => {
-  return createAuthEndpoint(
-    path,
-    {
-      method: "POST",
-      metadata: { ...HIDE_METADATA },
-      disableBody: true,
-      use: [sessionMiddleware],
-    },
-    async (ctx) => {
-      const paystack = getPaystackOps(options.paystackClient);
-      try {
-        const raw = await paystack?.product?.list({});
-        const productsData =
-          unwrapSdkResult<components["schemas"]["ProductListsResponseArray"][]>(raw);
-
-        if (!Array.isArray(productsData)) {
-          return ctx.json({ products: [] });
-        }
-
-        for (const product of productsData) {
-          const paystackId = String(product.id);
-          const existing = await ctx.context.adapter.findOne<PaystackProduct>({
-            model: "paystackProduct",
-            where: [{ field: "paystackId", value: paystackId }],
-          });
-
-          const productFields = {
-            name: product.name ?? "",
-            description: product.description ?? "",
-            price: product.price ?? 0,
-            currency: product.currency ?? "",
-            quantity: product.quantity ?? 0,
-            unlimited:
-              product.unlimited !== undefined &&
-              product.unlimited !== null &&
-              product.unlimited !== false,
-            paystackId,
-            slug:
-              (product as unknown as { slug?: string }).slug ??
-              product.name?.toLowerCase().replace(/\s+/g, "-") ??
-              "",
-            metadata:
-              (product as unknown as { metadata?: unknown }).metadata !== undefined &&
-              (product as unknown as { metadata?: unknown }).metadata !== null
-                ? JSON.stringify((product as unknown as { metadata?: unknown }).metadata)
-                : undefined,
-            updatedAt: new Date(),
-          };
-
-          if (existing !== undefined && existing !== null) {
-            await ctx.context.adapter.update({
-              model: "paystackProduct",
-              update: productFields,
-              where: [{ field: "id", value: String(existing.id) }],
-            });
-          } else {
-            await ctx.context.adapter.create({
-              model: "paystackProduct",
-              data: { ...productFields, createdAt: new Date() },
-            });
-          }
-        }
-
-        return ctx.json({ status: "success", count: productsData.length });
-      } catch (error: unknown) {
-        ctx.context.logger.error("Failed to sync products", error);
-        const errorMessage = error instanceof Error ? error.message : "Failed to sync products";
-        throw new APIError("BAD_REQUEST", {
-          message: errorMessage,
-        });
-      }
-    },
-  );
-};
-
 export const listProducts = <P extends string = "/list-products">(
   _options: AnyPaystackOptions,
   path: P = "/list-products" as P,
@@ -2555,118 +2194,8 @@ export const listProducts = <P extends string = "/list-products">(
       },
     },
     async (ctx) => {
-      const res = await ctx.context.adapter.findMany<PaystackProduct>({
-        model: "paystackProduct",
-      });
-      const sorted = res.sort((a, b) => a.name.localeCompare(b.name));
-      return ctx.json({ products: sorted });
-    },
-  );
-};
-
-export const syncPlans = <P extends string = "/sync-plans">(
-  options: AnyPaystackOptions,
-  path: P = "/sync-plans" as P,
-): StrictEndpoint<
-  P,
-  {
-    method: "POST";
-    metadata: {
-      scope: "server";
-    };
-    disableBody: true;
-    use: ((inputContext: MiddlewareInputContext<MiddlewareOptions>) => Promise<{
-      session: {
-        session: Record<string, unknown> & {
-          id: string;
-          createdAt: Date;
-          updatedAt: Date;
-          userId: string;
-          expiresAt: Date;
-          token: string;
-          ipAddress?: string | null | undefined;
-          userAgent?: string | null | undefined;
-        };
-        user: Record<string, unknown> & {
-          id: string;
-          createdAt: Date;
-          updatedAt: Date;
-          email: string;
-          emailVerified: boolean;
-          name: string;
-          image?: string | null | undefined;
-        };
-      };
-    }>)[];
-  },
-  {
-    status: string;
-    count: number;
-  }
-> => {
-  return createAuthEndpoint(
-    path,
-    {
-      method: "POST",
-      metadata: { ...HIDE_METADATA },
-      disableBody: true,
-      use: [sessionMiddleware],
-    },
-    async (ctx) => {
-      const paystack = getPaystackOps(options.paystackClient);
-      try {
-        const raw = await paystack?.plan?.list();
-        const plansData = unwrapSdkResult<components["schemas"]["PlanListResponseArray"][]>(raw);
-
-        if (!Array.isArray(plansData)) {
-          return ctx.json({ status: "success", count: 0 });
-        }
-
-        for (const plan of plansData) {
-          const paystackId = String(plan.id);
-          const existing = await ctx.context.adapter.findOne<PaystackPlan>({
-            model: "paystackPlan",
-            where: [{ field: "paystackId", value: paystackId }],
-          });
-
-          const planData = {
-            name: plan.name ?? "",
-            description: plan.description ?? "",
-            amount: plan.amount ?? 0,
-            currency: plan.currency ?? "",
-            interval: plan.interval ?? "",
-            planCode: plan.plan_code ?? "",
-            paystackId,
-            metadata:
-              (plan as unknown as { metadata?: unknown }).metadata !== undefined &&
-              (plan as unknown as { metadata?: unknown }).metadata !== null
-                ? JSON.stringify((plan as unknown as { metadata?: unknown }).metadata)
-                : undefined,
-            updatedAt: new Date(),
-          };
-
-          if (existing !== undefined && existing !== null) {
-            await ctx.context.adapter.update({
-              model: "paystackPlan",
-              update: planData,
-              where: [{ field: "id", value: existing.id! }],
-            });
-          } else {
-            await ctx.context.adapter.create({
-              model: "paystackPlan",
-              data: { ...planData, createdAt: new Date() },
-            });
-          }
-        }
-
-        return ctx.json({ status: "success", count: plansData.length });
-      } catch (error: unknown) {
-        ctx.context.logger.error("Failed to sync plans", error);
-        const errorMessage = error instanceof Error ? error.message : "Failed to sync plans";
-        throw new APIError("BAD_REQUEST", {
-          message: errorMessage,
-        });
-      }
+      const products = await createBillingStore(ctx).listProducts();
+      return ctx.json({ products });
     },
   );
 };
@@ -2718,9 +2247,7 @@ export const listPlans = <P extends string = "/list-plans">(
     },
     async (ctx) => {
       try {
-        const plans = await ctx.context.adapter.findMany<PaystackPlan>({
-          model: "paystackPlan",
-        });
+        const plans = await createBillingStore(ctx).listPlans();
         return ctx.json({ plans });
       } catch (error: unknown) {
         ctx.context.logger.error("Failed to list plans", error);
@@ -2771,140 +2298,3 @@ export const getConfig = <P extends string = "/get-config">(
 };
 
 export { PAYSTACK_ERROR_CODES };
-
-export const chargeRecurringSubscription = <P extends string = "/charge-recurring-subscription">(
-  options: AnyPaystackOptions,
-  path: P = "/charge-recurring-subscription" as P,
-): StrictEndpoint<
-  P,
-  {
-    method: "POST";
-    body: z.ZodObject<
-      {
-        subscriptionId: z.ZodString;
-        amount: z.ZodOptional<z.ZodNumber>;
-      },
-      z.core.$strip
-    >;
-  },
-  ChargeRecurringSubscriptionResult
-> => {
-  return createAuthEndpoint(
-    path,
-    {
-      method: "POST",
-      body: z.object({
-        subscriptionId: z.string(),
-        amount: z.number().optional(),
-      }),
-    },
-    async (ctx) => {
-      const { subscriptionId, amount: bodyAmount } = ctx.body;
-      const subscription = await ctx.context.adapter.findOne<Subscription>({
-        model: "subscription",
-        where: [{ field: "id", value: subscriptionId }],
-      });
-
-      if (subscription === undefined || subscription === null) {
-        throw new APIError("NOT_FOUND", { message: "Subscription not found" });
-      }
-
-      if (
-        subscription.paystackAuthorizationCode === undefined ||
-        subscription.paystackAuthorizationCode === null ||
-        subscription.paystackAuthorizationCode === ""
-      ) {
-        throw new APIError("BAD_REQUEST", {
-          message: "No authorization code found for this subscription",
-        });
-      }
-
-      const plans = await getPlans(options.subscription);
-      const plan = plans.find((p) => p.name.toLowerCase() === subscription.plan.toLowerCase());
-
-      if (plan === undefined || plan === null) {
-        throw new APIError("NOT_FOUND", { message: "Plan not found" });
-      }
-
-      const amount = bodyAmount ?? plan.amount;
-      if (amount === undefined || amount === null) {
-        throw new APIError("BAD_REQUEST", { message: "Plan amount is not defined" });
-      }
-
-      let email: string | undefined;
-      const referenceId = subscription.referenceId;
-      if (referenceId !== undefined && referenceId !== null && referenceId !== "") {
-        const user = await ctx.context.adapter.findOne<User>({
-          model: "user",
-          where: [{ field: "id", value: referenceId }],
-        });
-        if (user !== undefined && user !== null) {
-          email = user.email;
-        } else if (options.organization?.enabled === true) {
-          const ownerMember = await ctx.context.adapter.findOne<Member>({
-            model: "member",
-            where: [
-              { field: "organizationId", value: referenceId },
-              { field: "role", value: "owner" },
-            ],
-          });
-          if (ownerMember !== undefined && ownerMember !== null) {
-            const ownerUser = await ctx.context.adapter.findOne<User>({
-              model: "user",
-              where: [{ field: "id", value: ownerMember.userId }],
-            });
-            email = ownerUser?.email;
-          }
-        }
-      }
-
-      if (email === undefined || email === null || email === "") {
-        throw new APIError("NOT_FOUND", { message: "User email not found" });
-      }
-
-      const finalCurrency = plan.currency ?? "NGN";
-      if (!validateMinAmount(amount, finalCurrency)) {
-        throw new APIError("BAD_REQUEST", {
-          message: `Amount ${amount} is less than the minimum required for ${finalCurrency}.`,
-          status: 400,
-        });
-      }
-
-      const paystack = getPaystackOps(options.paystackClient);
-      const chargeResRaw = await paystack?.transaction?.chargeAuthorization({
-        body: {
-          email,
-          amount,
-          authorization_code: subscription.paystackAuthorizationCode,
-          reference: `rec_${subscription.id}_${Date.now()}`,
-          metadata: JSON.stringify({
-            subscriptionId,
-            referenceId,
-          }),
-        },
-      });
-
-      const chargeData = unwrapSdkResult<PaystackChargeAuthorizationResponse>(chargeResRaw);
-
-      if (chargeData?.status === "success" && chargeData.reference !== undefined) {
-        const now = new Date();
-        const nextPeriodEnd = getNextPeriodEnd(now, plan.interval ?? "monthly");
-
-        await ctx.context.adapter.update({
-          model: "subscription",
-          update: {
-            periodStart: now,
-            periodEnd: nextPeriodEnd,
-            updatedAt: now,
-            paystackTransactionReference: chargeData.reference,
-          },
-          where: [{ field: "id", value: subscription.id }],
-        });
-
-        return ctx.json({ status: "success", data: chargeData });
-      }
-
-      return ctx.json({ status: "failed", data: chargeData }, { status: 400 });
-    },
-  );
-};

--- a/src/subscription-lifecycle.ts
+++ b/src/subscription-lifecycle.ts
@@ -1,0 +1,210 @@
+import type { GenericEndpointContext } from "better-auth";
+import { APIError } from "better-auth/api";
+import type { components } from "@alexasomba/paystack-node";
+
+import { createBillingStore } from "./billing-store";
+import { createPaystackAdapter } from "./paystack-sdk";
+import {
+  assertLocallyManagedSubscription,
+  calculatePlanAmount,
+  getPlanByName,
+  getPlanSeatAmount,
+} from "./utils";
+import type {
+  AnyPaystackOptions,
+  PaystackChargeAuthorizationResponse,
+  PaystackCheckoutChannel,
+  PaystackPlan,
+} from "./types";
+
+export type ProratedUpgradeOutcome =
+  | {
+      kind: "completed";
+      status: "success";
+      message: string;
+      prorated: true;
+    }
+  | {
+      kind: "checkout";
+      url: string | undefined;
+      reference: string | undefined;
+      accessCode: string | undefined;
+      redirect: true;
+    };
+
+export async function handleProratedUpgrade(
+  ctx: GenericEndpointContext,
+  options: AnyPaystackOptions,
+  input: {
+    plan: PaystackPlan;
+    referenceId: string;
+    quantity?: number;
+    targetEmail: string;
+    userId: string;
+    finalCurrency: string;
+    callbackURL?: string;
+    allowedSubscriptionChannels?: PaystackCheckoutChannel[];
+  },
+): Promise<ProratedUpgradeOutcome | null> {
+  const store = createBillingStore(ctx);
+  const existingSub = await store.findCurrentSubscription(input.referenceId);
+  if (
+    existingSub?.status !== "active" ||
+    existingSub.paystackSubscriptionCode === undefined ||
+    existingSub.paystackSubscriptionCode === null ||
+    existingSub.paystackSubscriptionCode === "" ||
+    existingSub.periodEnd === undefined ||
+    existingSub.periodEnd === null ||
+    existingSub.periodStart === undefined ||
+    existingSub.periodStart === null
+  ) {
+    return null;
+  }
+
+  const now = new Date();
+  const periodEnd = new Date(existingSub.periodEnd);
+  const periodStart = new Date(existingSub.periodStart);
+
+  const totalDays = Math.max(
+    1,
+    Math.ceil((periodEnd.getTime() - periodStart.getTime()) / (1000 * 60 * 60 * 24)),
+  );
+  const remainingDays = Math.max(
+    0,
+    Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)),
+  );
+
+  let oldAmount = 0;
+  if (existingSub.plan !== "") {
+    const oldPlan =
+      (await getPlanByName(options, existingSub.plan)) ??
+      (await store.findPlanByName(existingSub.plan));
+    if (oldPlan !== undefined && oldPlan !== null) {
+      oldAmount = calculatePlanAmount(oldPlan, existingSub.seats);
+    }
+  }
+
+  let membersCount = 1;
+  let newSeatCount: number;
+  let newAmount: number;
+  try {
+    assertLocallyManagedSubscription(existingSub, "plan or seat changes");
+    if (getPlanSeatAmount(input.plan) !== undefined) {
+      const members = await store.listMembers(input.referenceId);
+      membersCount = members.length > 0 ? members.length : 1;
+    }
+    newSeatCount = input.quantity ?? existingSub.seats ?? membersCount;
+    newAmount = calculatePlanAmount(input.plan, newSeatCount);
+  } catch (error: unknown) {
+    throw new APIError("BAD_REQUEST", {
+      message: error instanceof Error ? error.message : "Invalid seat configuration for plan.",
+    });
+  }
+
+  const costDifference = newAmount - oldAmount;
+  const prorationMetadata = {
+    type: "proration",
+    subscriptionId: existingSub.id,
+    referenceId: input.referenceId,
+    newPlan: input.plan.name.toLowerCase(),
+    oldPlan: existingSub.plan,
+    newSeatCount,
+    remainingDays,
+  };
+  let completedProrationReference: string | undefined;
+
+  if (costDifference > 0 && remainingDays > 0) {
+    const proratedAmount = Math.round((costDifference / totalDays) * remainingDays);
+    if (proratedAmount < 5000) {
+      throw new APIError("BAD_REQUEST", {
+        message:
+          "Prorated upgrade amount is below Paystack's minimum charge. Schedule the change for period end instead.",
+        status: 400,
+      });
+    }
+
+    const paystack = createPaystackAdapter(options.paystackClient);
+    if (
+      existingSub.paystackAuthorizationCode !== undefined &&
+      existingSub.paystackAuthorizationCode !== null &&
+      existingSub.paystackAuthorizationCode !== ""
+    ) {
+      const sdkRes = (await paystack.chargeAuthorization({
+        email: input.targetEmail,
+        amount: proratedAmount,
+        authorization_code: existingSub.paystackAuthorizationCode,
+        reference: `upg_${existingSub.id}_${Date.now()}_${Math.random().toString(36).substring(7)}`,
+        metadata: JSON.stringify(prorationMetadata),
+      })) as PaystackChargeAuthorizationResponse;
+
+      if (sdkRes?.status !== "success") {
+        throw new APIError("BAD_REQUEST", {
+          message: "Failed to process prorated charge via saved authorization.",
+        });
+      }
+
+      await store.createTransaction({
+        reference: sdkRes.reference ?? "",
+        paystackId: sdkRes.id !== undefined && sdkRes.id !== null ? String(sdkRes.id) : undefined,
+        referenceId: input.referenceId,
+        userId: input.userId,
+        amount: sdkRes.amount ?? proratedAmount,
+        currency: sdkRes.currency ?? input.finalCurrency,
+        status: "success",
+        plan: input.plan.name.toLowerCase(),
+        metadata: JSON.stringify(prorationMetadata),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+      completedProrationReference = sdkRes.reference ?? undefined;
+    } else {
+      const initRes = await paystack.initializeTransaction({
+        email: input.targetEmail,
+        amount: proratedAmount,
+        currency: input.finalCurrency,
+        callback_url: input.callbackURL ?? undefined,
+        metadata: JSON.stringify(prorationMetadata),
+        ...(input.allowedSubscriptionChannels !== undefined
+          ? { channels: input.allowedSubscriptionChannels }
+          : {}),
+      } as components["schemas"]["TransactionInitialize"]);
+
+      await store.createTransaction({
+        reference: initRes?.reference ?? "",
+        referenceId: input.referenceId,
+        userId: input.userId,
+        amount: proratedAmount,
+        currency: input.finalCurrency,
+        status: "pending",
+        plan: input.plan.name.toLowerCase(),
+        metadata: JSON.stringify(prorationMetadata),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      return {
+        kind: "checkout",
+        url: initRes?.authorization_url,
+        reference: initRes?.reference,
+        accessCode: initRes?.access_code,
+        redirect: true,
+      };
+    }
+  }
+
+  await store.updateSubscription(existingSub.id, {
+    plan: input.plan.name,
+    seats: newSeatCount,
+    ...(completedProrationReference !== undefined
+      ? { paystackTransactionReference: completedProrationReference }
+      : {}),
+    updatedAt: new Date(),
+  });
+
+  return {
+    kind: "completed",
+    status: "success",
+    message: "Subscription successfully upgraded with prorated charge.",
+    prorated: true,
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,8 @@ import type {
   Subscription,
   PaystackProductResponse,
 } from "./types";
-import { unwrapSdkResult } from "./paystack-sdk";
+import { createBillingStore } from "./billing-store";
+import { createPaystackAdapter } from "./paystack-sdk";
 
 export function getPlanSeatAmount(plan: PaystackPlan): number | undefined {
   if (plan.seatAmount !== undefined) {
@@ -199,16 +200,11 @@ export async function syncProductQuantityFromPaystack(
   productName: string,
   paystackClient: PaystackClientLike,
 ): Promise<void> {
+  const store = createBillingStore(ctx);
   // Find the local product record (by name or slug)
-  let localProduct = await ctx.context.adapter.findOne<PaystackProduct>({
-    model: "paystackProduct",
-    where: [{ field: "name", value: productName }],
-  });
+  let localProduct = await store.findProductByName(productName);
 
-  localProduct ??= await ctx.context.adapter.findOne<PaystackProduct>({
-    model: "paystackProduct",
-    where: [{ field: "slug", value: productName.toLowerCase().replace(/\s+/g, "-") }],
-  });
+  localProduct ??= await store.findProductBySlug(productName.toLowerCase().replace(/\s+/g, "-"));
 
   if (
     localProduct?.paystackId === undefined ||
@@ -222,10 +218,9 @@ export async function syncProductQuantityFromPaystack(
       typeof localProduct.quantity === "number" &&
       localProduct.quantity > 0
     ) {
-      await ctx.context.adapter.update({
-        model: "paystackProduct",
-        update: { quantity: localProduct.quantity - 1, updatedAt: new Date() },
-        where: [{ field: "id", value: localProduct.id }],
+      await store.updateProduct(localProduct.id, {
+        quantity: localProduct.quantity - 1,
+        updatedAt: new Date(),
       });
     }
     return;
@@ -237,15 +232,15 @@ export async function syncProductQuantityFromPaystack(
     if (!Number.isFinite(paystackProductId)) {
       return;
     }
-    const raw = await paystackClient.product?.fetch(paystackProductId);
-    const sdkRes = unwrapSdkResult<PaystackProductResponse>(raw);
+    const sdkRes = (await createPaystackAdapter(paystackClient).fetchProduct(
+      paystackProductId,
+    )) as PaystackProductResponse;
     const remoteQuantity = sdkRes?.quantity;
 
     if (remoteQuantity !== undefined && localProduct.id !== undefined) {
-      await ctx.context.adapter.update({
-        model: "paystackProduct",
-        update: { quantity: remoteQuantity, updatedAt: new Date() },
-        where: [{ field: "id", value: localProduct.id }],
+      await store.updateProduct(localProduct.id, {
+        quantity: remoteQuantity,
+        updatedAt: new Date(),
       });
     }
   } catch {
@@ -256,10 +251,9 @@ export async function syncProductQuantityFromPaystack(
       typeof localProduct.quantity === "number" &&
       localProduct.quantity > 0
     ) {
-      await ctx.context.adapter.update({
-        model: "paystackProduct",
-        update: { quantity: localProduct.quantity - 1, updatedAt: new Date() },
-        where: [{ field: "id", value: localProduct.id }],
+      await store.updateProduct(localProduct.id, {
+        quantity: localProduct.quantity - 1,
+        updatedAt: new Date(),
       });
     }
   }
@@ -269,15 +263,10 @@ export async function decrementProductQuantity(
   ctx: GenericEndpointContext,
   productName: string,
 ): Promise<void> {
-  let product = await ctx.context.adapter.findOne<PaystackProduct>({
-    model: "paystackProduct",
-    where: [{ field: "name", value: productName }],
-  });
+  const store = createBillingStore(ctx);
+  let product = await store.findProductByName(productName);
 
-  product ??= await ctx.context.adapter.findOne<PaystackProduct>({
-    model: "paystackProduct",
-    where: [{ field: "slug", value: productName.toLowerCase().replace(/\s+/g, "-") }],
-  });
+  product ??= await store.findProductBySlug(productName.toLowerCase().replace(/\s+/g, "-"));
 
   if (product !== undefined && product !== null) {
     if (
@@ -286,13 +275,9 @@ export async function decrementProductQuantity(
       product.quantity > 0 &&
       product.id !== undefined
     ) {
-      await ctx.context.adapter.update({
-        model: "paystackProduct",
-        update: {
-          quantity: product.quantity - 1,
-          updatedAt: new Date(),
-        },
-        where: [{ field: "id", value: product.id }],
+      await store.updateProduct(product.id, {
+        quantity: product.quantity - 1,
+        updatedAt: new Date(),
       });
     }
   }
@@ -305,11 +290,8 @@ export async function syncSubscriptionSeats(
 ): Promise<void> {
   if (options.subscription?.enabled !== true) return;
 
-  const adapter = ctx.context.adapter;
-  const subscription = await adapter.findOne<Subscription>({
-    model: "subscription",
-    where: [{ field: "referenceId", value: organizationId }],
-  });
+  const store = createBillingStore(ctx);
+  const subscription = await store.findCurrentSubscription(organizationId);
 
   if (
     subscription?.paystackSubscriptionCode === undefined ||
@@ -323,10 +305,7 @@ export async function syncSubscriptionSeats(
   const seatAmount = getPlanSeatAmount(plan);
   if (seatAmount === undefined) return;
 
-  const members = await adapter.findMany({
-    model: "member",
-    where: [{ field: "organizationId", value: organizationId }],
-  });
+  const members = await store.listMembers(organizationId);
 
   const quantity = members.length;
 
@@ -334,13 +313,9 @@ export async function syncSubscriptionSeats(
     assertLocallyManagedSubscription(subscription, "automatic seat sync");
 
     // Locally managed subscriptions renew via saved authorizations, so seat count lives in our DB.
-    await adapter.update({
-      model: "subscription",
-      where: [{ field: "id", value: subscription.id }],
-      update: {
-        seats: quantity,
-        updatedAt: new Date(),
-      },
+    await store.updateSubscription(subscription.id, {
+      seats: quantity,
+      updatedAt: new Date(),
     });
   } catch (e: unknown) {
     const log = ctx.context.logger;


### PR DESCRIPTION
## Summary
- add domain context for billing reference, billing store, Paystack adapter, trusted operations, and subscription lifecycle
- centralize billing reference authorization through a single reference access module
- add billing store and Paystack adapter seams, then migrate trusted operations and low-level billing helpers onto them
- remove stale trusted-operation route wrappers and extract proration handling from the route implementation

## Verification
- vp check
- vp test