### PR TITLE
Make release publishing recoverable

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish, for example v2.4.4"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -17,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - uses: actions/setup-node@v4
         with:
@@ -25,11 +32,12 @@ jobs:
       - name: Validate release tag
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error ::Release tags must use vX.X.X format, for example v2.4.1."
             exit 1
           fi
+          echo "release_tag=$TAG" >> $GITHUB_ENV
 
       - uses: pnpm/action-setup@v4
         with: {}
@@ -49,12 +57,13 @@ jobs:
         id: determine_npm_tag
         shell: bash
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="$release_tag"
           if [[ "$TAG" =~ -(next|canary|beta|rc) ]]; then
             NPM_TAG=${BASH_REMATCH[1]}
           else
             git fetch origin main
-            CURRENT_BRANCH=$(git branch -r --contains "$GITHUB_SHA" | grep -E 'origin/(main|v[0-9]+\.[0-9]+\.x-latest)' | head -1 | sed 's/.*origin\///')
+            RELEASE_SHA=$(git rev-parse HEAD)
+            CURRENT_BRANCH=$(git branch -r --contains "$RELEASE_SHA" | grep -E 'origin/(main|v[0-9]+\.[0-9]+\.x-latest)' | head -1 | sed 's/.*origin\///')
 
             if [[ "$CURRENT_BRANCH" == "main" ]]; then
               NPM_TAG="latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,10 +62,9 @@
 
 ## [2.4.4](https://github.com/alexasomba/better-auth-paystack/compare/v2.4.3...v2.4.4) (2026-05-12)
 
-
 ### Documentation
 
-* add maintenance-focused tanstack intent skills ([#130](https://github.com/alexasomba/better-auth-paystack/issues/130)) ([5f5c2d2](https://github.com/alexasomba/better-auth-paystack/commit/5f5c2d26860ccb62f4fabde4a759cf6d5aa4ce0f))
+- add maintenance-focused tanstack intent skills ([#130](https://github.com/alexasomba/better-auth-paystack/issues/130)) ([5f5c2d2](https://github.com/alexasomba/better-auth-paystack/commit/5f5c2d26860ccb62f4fabde4a759cf6d5aa4ce0f))
 
 ## [2.4.3](https://github.com/alexasomba/better-auth-paystack/compare/v2.4.2...v2.4.3) (2026-05-12)
 

--- a/_artifacts/domain_map.yaml
+++ b/_artifacts/domain_map.yaml
@@ -1,5 +1,5 @@
 library:
-  name: '@alexasomba/better-auth-paystack'
+  name: "@alexasomba/better-auth-paystack"
   version: 2.4.4
   repository: https://github.com/alexasomba/better-auth-paystack
   description: >-

--- a/_artifacts/skill_tree.yaml
+++ b/_artifacts/skill_tree.yaml
@@ -1,5 +1,5 @@
 library:
-  name: '@alexasomba/better-auth-paystack'
+  name: "@alexasomba/better-auth-paystack"
   version: 2.4.4
   repository: https://github.com/alexasomba/better-auth-paystack
   license: MIT
@@ -12,7 +12,7 @@ library:
 generated_from:
   domain_map: _artifacts/domain_map.yaml
   skill_spec: _artifacts/skill_spec.md
-generated_at: '2026-05-09T00:00:00Z'
+generated_at: "2026-05-09T00:00:00Z"
 skills:
   - name: better-auth-paystack/setup
     slug: setup


### PR DESCRIPTION
## Summary
- use RELEASE_PLEASE_TOKEN for Release Please so release PR/tag updates are not constrained by GITHUB_TOKEN event suppression
- add workflow_dispatch to the Release workflow so a missed tag publish can be retried by passing a tag such as v2.4.4
- use the checked-out release tag commit when determining the npm dist-tag
- apply formatter cleanup to release artifact files required by vp check

## Verification
- vp check