### PR TITLE
Add skills-npm discovery support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ test_output*
 
 typecheck_output*
 GEMINI.md
+
+# Agent skills from npm packages (managed by skills-npm)
+**/skills/npm-*

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Use [TanStack Intent](https://www.npmjs.com/package/@tanstack/intent) when you w
 
 ```bash
 npx @tanstack/intent@latest list
-npx @tanstack/intent@latest load @alexasomba/better-auth-paystack#setup
-npx @tanstack/intent@latest load @alexasomba/better-auth-paystack#testing-and-fixtures
+npx @tanstack/intent@latest load @alexasomba/better-auth-paystack#better-auth-paystack-setup
+npx @tanstack/intent@latest load @alexasomba/better-auth-paystack#paystack-testing-fixtures
 ```
 
 If you use an AI agent, run `npx @tanstack/intent@latest install` in your project so the agent knows how to discover package skills.
@@ -33,7 +33,7 @@ This package also ships skills in the npm package under `skills/*/SKILL.md`, so 
 
 ```bash
 npm install @alexasomba/better-auth-paystack
-npx skills-npm --yes --include @alexasomba/better-auth-paystack
+npx skills-npm --yes
 ```
 
 For this repository, maintainers can run `pnpm run skills:dry-run` to preview discovery through the TanStack example fixture or `pnpm run skills:install` to create local agent skill symlinks from that fixture.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A TypeScript-first plugin that integrates Paystack into [Better Auth](https://ww
 
 ## AI Agent Skills
 
-This package publishes [TanStack Intent](https://www.npmjs.com/package/@tanstack/intent) skills so AI coding agents can load package-specific guidance for setup, subscriptions, organization billing, TanStack Start integration, client APIs, webhooks, local subscription lifecycle, schema changes, and testing.
+This package publishes agent skills so AI coding agents can load package-specific guidance for setup, subscriptions, organization billing, TanStack Start integration, client APIs, webhooks, local subscription lifecycle, schema changes, and testing.
+
+Use [TanStack Intent](https://www.npmjs.com/package/@tanstack/intent) when you want to explicitly list or load individual skills:
 
 ```bash
 npx @tanstack/intent@latest list
@@ -26,6 +28,15 @@ npx @tanstack/intent@latest load @alexasomba/better-auth-paystack#testing-and-fi
 ```
 
 If you use an AI agent, run `npx @tanstack/intent@latest install` in your project so the agent knows how to discover package skills.
+
+This package also ships skills in the npm package under `skills/*/SKILL.md`, so projects can use [skills-npm](https://www.npmjs.com/package/skills-npm) to symlink installed package skills for compatible agents:
+
+```bash
+npm install @alexasomba/better-auth-paystack
+npx skills-npm --yes --include @alexasomba/better-auth-paystack
+```
+
+For this repository, maintainers can run `pnpm run skills:dry-run` to preview discovery through the TanStack example fixture or `pnpm run skills:install` to create local agent skill symlinks from that fixture.
 
 ## Features
 

--- a/examples/tanstack/.gitignore
+++ b/examples/tanstack/.gitignore
@@ -12,3 +12,6 @@ count.txt
 .vinxi
 todos.json
 .dev.vars
+
+# Agent skills from npm packages (managed by skills-npm)
+**/skills/npm-*

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
     "lint": "vp lint src",
     "lint:package": "publint run --strict",
     "lint:types": "attw --profile esm-only --pack .",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "skills:install": "skills-npm --cwd examples/tanstack --yes --force",
+    "skills:dry-run": "skills-npm --cwd examples/tanstack --dry-run --yes --agents universal --force"
   },
   "dependencies": {
     "@alexasomba/paystack-node": "catalog:",
@@ -101,6 +103,7 @@
     "eslint-plugin-react-hooks": "catalog:",
     "eslint-plugin-unicorn": "catalog:",
     "publint": "catalog:",
+    "skills-npm": "^1.1.1",
     "typescript": "catalog:",
     "typescript-eslint": "catalog:",
     "vite-plus": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       publint:
         specifier: 'catalog:'
         version: 0.3.20
+      skills-npm:
+        specifier: ^1.1.1
+        version: 1.1.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -745,6 +748,14 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@clack/core@1.3.1':
+    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.4.0':
+    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -1716,6 +1727,9 @@ packages:
   '@publint/pack@0.1.4':
     resolution: {integrity: sha512-HDVTWq3H0uTXiU0eeSQntcVUTPP3GamzeXI41+x7uU9J65JgWQh3qWZHblR1i0npXfFtF+mxBiU2nJH8znxWnQ==}
     engines: {node: '>=18'}
+
+  '@quansync/fs@1.0.0':
+    resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -2782,6 +2796,9 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -2936,6 +2953,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  cac@7.0.0:
+    resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
+    engines: {node: '>=20.19.0'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -3339,6 +3360,11 @@ packages:
     resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -3365,6 +3391,10 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3374,8 +3404,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.2:
     resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fast-xml-builder@1.1.9:
     resolution: {integrity: sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==}
@@ -3496,6 +3535,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
   h3@2.0.1-rc.20:
     resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
     engines: {node: '>=20.11.1'}
@@ -3581,6 +3624,10 @@ packages:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3647,6 +3694,10 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+    hasBin: true
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
@@ -3690,6 +3741,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -4092,6 +4147,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  quansync@1.0.0:
+    resolution: {integrity: sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA==}
+
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
@@ -4181,6 +4239,10 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4239,6 +4301,13 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  skills-npm@1.1.1:
+    resolution: {integrity: sha512-qbRSzorWK3fVdpKzZquehYlWzmC29/MOh8AqWoX7NAZiCSAX/RuTpyqAml7hWBe7NM9DDx472kZ0hKO7CCXRkA==}
+    hasBin: true
+
   skin-tone@2.0.0:
     resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
     engines: {node: '>=8'}
@@ -4253,6 +4322,9 @@ packages:
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
   srvx@0.11.15:
     resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
@@ -4284,6 +4356,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -4447,6 +4523,12 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  unconfig-core@7.5.0:
+    resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  unconfig@7.5.0:
+    resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -4653,6 +4735,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
 
   xml-crypto@6.1.2:
     resolution: {integrity: sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==}
@@ -5034,6 +5120,18 @@ snapshots:
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
+
+  '@clack/core@1.3.1':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.4.0':
+    dependencies:
+      '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -5729,6 +5827,10 @@ snapshots:
   '@poppinss/exception@1.2.3': {}
 
   '@publint/pack@0.1.4': {}
+
+  '@quansync/fs@1.0.0':
+    dependencies:
+      quansync: 1.0.0
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -6933,6 +7035,10 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -7088,6 +7194,8 @@ snapshots:
   builtin-modules@5.1.0: {}
 
   cac@6.7.14: {}
+
+  cac@7.0.0: {}
 
   callsites@3.1.0: {}
 
@@ -7558,6 +7666,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -7578,13 +7688,27 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.9:
     dependencies:
@@ -7683,6 +7807,13 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
@@ -7750,6 +7881,8 @@ snapshots:
     dependencies:
       builtin-modules: 5.1.0
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -7794,6 +7927,11 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-yaml@3.14.2:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
 
   js-yaml@4.1.1:
     dependencies:
@@ -7844,6 +7982,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   kleur@4.1.5: {}
 
@@ -8240,6 +8380,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  quansync@1.0.0: {}
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -8342,6 +8484,11 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -8413,6 +8560,19 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  sisteransi@1.0.5: {}
+
+  skills-npm@1.1.1:
+    dependencies:
+      '@clack/prompts': 1.4.0
+      cac: 7.0.0
+      gray-matter: 4.0.3
+      picocolors: 1.1.1
+      tinyglobby: 0.2.16
+      unconfig: 7.5.0
+      xdg-basedir: 5.1.0
+      yaml: 2.8.3
+
   skin-tone@2.0.0:
     dependencies:
       unicode-emoji-modifier-base: 1.0.0
@@ -8426,6 +8586,8 @@ snapshots:
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
+
+  sprintf-js@1.0.3: {}
 
   srvx@0.11.15: {}
 
@@ -8456,6 +8618,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:
@@ -8606,6 +8770,19 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.3: {}
+
+  unconfig-core@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      quansync: 1.0.0
+
+  unconfig@7.5.0:
+    dependencies:
+      '@quansync/fs': 1.0.0
+      defu: 6.1.7
+      jiti: 2.7.0
+      quansync: 1.0.0
+      unconfig-core: 7.5.0
 
   undici-types@7.16.0: {}
 
@@ -8874,6 +9051,8 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.20.0: {}
+
+  xdg-basedir@5.1.0: {}
 
   xml-crypto@6.1.2:
     dependencies:

--- a/skills-npm.config.ts
+++ b/skills-npm.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "skills-npm";
+
+export default defineConfig({
+  recursive: true,
+  include: ["@alexasomba/better-auth-paystack"],
+});

--- a/skills/better-auth-paystack-setup/SKILL.md
+++ b/skills/better-auth-paystack-setup/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: setup
+name: better-auth-paystack-setup
 description: >
   Configure @alexasomba/better-auth-paystack with Better Auth. Use when adding the paystack() server plugin, paystackClient() client plugin, schema overrides, products/plans, webhook secrets, or canonical authClient.paystack/subscription/transaction actions.
 type: core

--- a/skills/better-auth-paystack-setup/agents/openai.yaml
+++ b/skills/better-auth-paystack-setup/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Setup"
+  short_description: "Server and client plugin setup guidance"
+  default_prompt: "Use $better-auth-paystack-setup to configure the Better Auth Paystack server and client plugins."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-billing-flows/SKILL.md
+++ b/skills/paystack-billing-flows/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: subscriptions-and-transactions
+name: paystack-billing-flows
 description: >
   Build Paystack transaction and subscription flows with @alexasomba/better-auth-paystack. Use for initialize/verify transaction, create/upgrade/cancel/restore/list subscriptions, products/plans, billing portal links, webhooks, chargeSubscriptionRenewal, syncPaystackProducts, and syncPaystackPlans.
 type: core

--- a/skills/paystack-billing-flows/agents/openai.yaml
+++ b/skills/paystack-billing-flows/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Billing Flows"
+  short_description: "Transactions, subscriptions, and billing flows"
+  default_prompt: "Use $paystack-billing-flows to build Paystack transaction, subscription, product, and billing portal flows."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-catalog-limits/SKILL.md
+++ b/skills/paystack-catalog-limits/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: billing-catalog-and-limits
+name: paystack-catalog-limits
 description: >
   Configure products, Paystack-native plans, local-managed plans, free trials, seat billing, resource limits, and catalog sync in @alexasomba/better-auth-paystack. Use when tasks mention planCode, freeTrial, trial eligibility, seatAmount, seatPlanCode, limits, products, syncPaystackProducts, or syncPaystackPlans.
 type: core

--- a/skills/paystack-catalog-limits/agents/openai.yaml
+++ b/skills/paystack-catalog-limits/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Catalog"
+  short_description: "Products, plans, trials, seats, and limits"
+  default_prompt: "Use $paystack-catalog-limits to configure Paystack products, subscription plans, free trials, seat billing, and resource limits."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-client-api/SKILL.md
+++ b/skills/paystack-client-api/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: client-api-contract
+name: paystack-client-api
 description: >
   Modify or use the @alexasomba/better-auth-paystack browser client API. Use for paystackClient(), authClient.paystack, authClient.transaction, authClient.subscription, initializeTransaction, verifyTransaction, listTransactions, listSubscriptions, listProducts, listPlans, subscription billingPortal/manageLink, cancel/restore aliases, BetterFetch throw option return types, and deprecated disable/enable behavior.
 type: core

--- a/skills/paystack-client-api/agents/openai.yaml
+++ b/skills/paystack-client-api/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Client API"
+  short_description: "Browser client methods and return contracts"
+  default_prompt: "Use $paystack-client-api to wire or review authClient Paystack, transaction, and subscription browser APIs."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-local-subscriptions/SKILL.md
+++ b/skills/paystack-local-subscriptions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: local-subscription-lifecycle
+name: paystack-local-subscriptions
 description: >
   Implement, debug, or test local-managed subscription behavior in @alexasomba/better-auth-paystack. Use for local plans without planCode, saved authorization renewal, chargeSubscriptionRenewal, seat billing, prorateAndCharge, pendingPlan, LOC_ subscription codes, trial transitions, schedule-at-period-end upgrades, and Paystack-managed vs local-managed behavior.
 type: core

--- a/skills/paystack-local-subscriptions/agents/openai.yaml
+++ b/skills/paystack-local-subscriptions/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Local Subs"
+  short_description: "Local subscriptions, renewals, and proration"
+  default_prompt: "Use $paystack-local-subscriptions to implement or debug local-managed Paystack subscription lifecycle behavior."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-organization-billing/SKILL.md
+++ b/skills/paystack-organization-billing/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: organization-billing
+name: paystack-organization-billing
 description: >
   Configure organization billing in @alexasomba/better-auth-paystack. Use for organization.enabled, Better Auth organization plugin setup, owner/admin default billing authorization, subscription.authorizeReference, organization Paystack customers, seats, invitations, members, and team limits.
 type: core

--- a/skills/paystack-organization-billing/agents/openai.yaml
+++ b/skills/paystack-organization-billing/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Org Billing"
+  short_description: "Organization billing, seats, and access"
+  default_prompt: "Use $paystack-organization-billing to configure Paystack billing for Better Auth organizations, seats, and admin access."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-schema-migrations/SKILL.md
+++ b/skills/paystack-schema-migrations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: schema-and-migrations
+name: paystack-schema-migrations
 description: >
   Modify or review @alexasomba/better-auth-paystack database schema behavior. Use for paystackProduct, paystackPlan, paystackTransaction, subscription, user.paystackCustomerCode, organization.paystackCustomerCode/email, Better Auth schema overrides, mergeSchema behavior, migrations, indexes, unique fields, and backward-compatible table or field changes.
 type: core

--- a/skills/paystack-schema-migrations/agents/openai.yaml
+++ b/skills/paystack-schema-migrations/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Schema"
+  short_description: "Database schema and migration guidance"
+  default_prompt: "Use $paystack-schema-migrations to review or change Better Auth Paystack schema and migration behavior."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-tanstack-start/SKILL.md
+++ b/skills/paystack-tanstack-start/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: tanstack-start
+name: paystack-tanstack-start
 description: >
   Integrate @alexasomba/better-auth-paystack in TanStack Start. Use for Better Auth API routes, tanstackStartCookies(), server functions, getRequestHeaders(), authClient Paystack actions, admin billing server functions, and Cloudflare Workers deployment.
 type: composition

--- a/skills/paystack-tanstack-start/agents/openai.yaml
+++ b/skills/paystack-tanstack-start/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack TanStack Start"
+  short_description: "TanStack Start integration patterns"
+  default_prompt: "Use $paystack-tanstack-start to integrate Better Auth Paystack in a TanStack Start application."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-testing-fixtures/SKILL.md
+++ b/skills/paystack-testing-fixtures/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: testing-and-fixtures
+name: paystack-testing-fixtures
 description: >
   Test @alexasomba/better-auth-paystack changes. Use for choosing focused vp test commands, Better Auth test clients, in-memory adapters, mocked Paystack SDK responses, webhook signatures, TanStack example tests, integration tests, type-safety tests, and verification before landing changes.
 type: core

--- a/skills/paystack-testing-fixtures/agents/openai.yaml
+++ b/skills/paystack-testing-fixtures/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Tests"
+  short_description: "Focused tests, mocks, and verification"
+  default_prompt: "Use $paystack-testing-fixtures to choose tests, fixtures, and verification commands for Better Auth Paystack changes."
+policy:
+  allow_implicit_invocation: true

--- a/skills/paystack-webhooks-events/SKILL.md
+++ b/skills/paystack-webhooks-events/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: webhooks-and-event-processing
+name: paystack-webhooks-events
 description: >
   Implement, debug, or test @alexasomba/better-auth-paystack webhook handling. Use for Paystack webhook signatures, trusted IP checks, webhook.secret/paystackWebhookSecret behavior, charge.success, subscription.create, subscription.disable, subscription.enable, product quantity updates, subscription status changes, metadata parsing, and event hooks.
 type: core

--- a/skills/paystack-webhooks-events/agents/openai.yaml
+++ b/skills/paystack-webhooks-events/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Better Auth Paystack Webhooks"
+  short_description: "Webhook signatures, events, and reconciliation"
+  default_prompt: "Use $paystack-webhooks-events to implement, debug, or test Paystack webhook event processing."
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary
- add skills-npm dependency, config, and maintainer scripts
- document skills-npm alongside TanStack Intent skill loading
- rename package skills to more discoverable Paystack-specific slugs and add OpenAI skill UI metadata

## Verification
- pnpm exec intent validate skills
- pnpm exec intent load @alexasomba/better-auth-paystack#better-auth-paystack-setup --path
- pnpm run skills:dry-run
- npm pack --dry-run --json
- vp check
- vp test