### PR TITLE
chore: lower Node engine floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@rollup/rollup-linux-x64-gnu": "catalog:"
   },
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "packageManager": "pnpm@11.0.9"
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,1 @@
+- 2026-06-01: Keep the published package engine floor at Node.js `>=22.0.0`; do not restore it to `>=24.0.0` during release cleanup unless explicitly requested.


### PR DESCRIPTION
## Summary
- Set package engine floor to Node.js `>=22.0.0`
- Record the release cleanup lesson so it is not reverted back to `>=24.0.0`

## Verification
- `node -e "const pkg=require('./package.json'); if(pkg.engines.node !== '>=22.0.0') throw new Error(pkg.engines.node)"`