### PR TITLE
ci: authenticate npm provenance publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -110,6 +110,8 @@ jobs:
       - name: Publish to npmjs with provenance
         if: ${{ steps.npmjs.outputs.exists != 'true' }}
         run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag latest
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure GitHub Packages registry
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- authenticate npmjs publish with the existing `NPM_TOKEN` secret
- keep `--provenance` and `id-token: write` so GitHub Actions still signs the published package provenance

## Validation

- `vp check --fix`
- `vp test`
- `vp pack`
- `pnpm run lint:package`
- `pnpm run lint:types`

Follow-up to #144 for the `v2.5.1` publish recovery.
