### PR TITLE
ci: use trusted publisher for npm auth

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -110,8 +110,6 @@ jobs:
       - name: Publish to npmjs with provenance
         if: ${{ steps.npmjs.outputs.exists != 'true' }}
         run: npm publish "${{ steps.pack.outputs.tarball }}" --access public --provenance --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure GitHub Packages registry
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- remove `NPM_TOKEN` from the npmjs publish step
- keep npm auth on Trusted Publisher/OIDC as intended by the simplified release plan

## Validation

- `vp check --fix`
- `vp test`
- `vp pack`
- workflow YAML parse check

The `NPM_TOKEN` path was tested in #146 and fails with `EOTP`, so npm release recovery must use the package's Trusted Publisher configuration instead.
