### PR TITLE
ci: authenticate npm publish with token

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_OPTIONAL: "true"
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - name: Resolve release tag
         shell: bash


### PR DESCRIPTION
## Summary
- wire the existing NPM_TOKEN repository secret into publish-npm.yml
- keep GitHub OIDC id-token permission and npm --provenance publishing enabled

## Context
The v3.0.0 publish run built and signed provenance successfully, but npm rejected the final publish with an auth/permission E404. This keeps the tag-owned publish flow while providing npm registry authentication.

## Checks
- git diff --check